### PR TITLE
Add txircd whenever the version number is displayed

### DIFF
--- a/txircd/user.py
+++ b/txircd/user.py
@@ -223,12 +223,13 @@ class IRCUser(irc.IRC):
             if self.ircd.runActionUntilFalse("register", self, users=[self]):
                 self.transport.loseConnection()
                 return
+            versionWithName = "txircd-{}".format(version)
             self.sendMessage(irc.RPL_WELCOME, ":Welcome to the Internet Relay Chat Network {}".format(self.hostmask()))
-            self.sendMessage(irc.RPL_YOURHOST, ":Your host is {}, running version {}".format(self.ircd.config["network_name"], version))
+            self.sendMessage(irc.RPL_YOURHOST, ":Your host is {}, running version {}".format(self.ircd.config["network_name"], versionWithName))
             self.sendMessage(irc.RPL_CREATED, ":This server was created {}".format(self.ircd.startupTime.replace(microsecond=0)))
             chanModes = "".join(["".join(modes.keys()) for modes in self.ircd.channelModes])
             chanModes += "".join(self.ircd.channelStatuses.keys())
-            self.sendMessage(irc.RPL_MYINFO, self.ircd.config["network_name"], version, "".join(["".join(modes.keys()) for modes in self.ircd.userModes]), chanModes)
+            self.sendMessage(irc.RPL_MYINFO, self.ircd.config["network_name"], versionWithName, "".join(["".join(modes.keys()) for modes in self.ircd.userModes]), chanModes)
             isupportList = self.ircd.generateISupportList()
             isupportMsgList = splitMessage(" ".join(isupportList), 350)
             for line in isupportMsgList:


### PR DESCRIPTION
I noticed whenever you connect, the version it displays is literally what's defined in **init**.py. I went ahead and prepended txircd, so the version is not just a number but includes the name of the IRCd as well.
