### PR TITLE
Implement the autojoin on connect module

### DIFF
--- a/txircd/modules/extra/conn_join.py
+++ b/txircd/modules/extra/conn_join.py
@@ -1,0 +1,27 @@
+from twisted.plugin import IPlugin
+from txircd.channel import IRCChannel
+from txircd.module_interface import IModuleData, ModuleData
+from zope.interface import implements
+
+class AutoJoin(ModuleData):
+    implements(IPlugin, IModuleData)
+
+    name = "AutoJoin"
+
+    def hookIRCd(self, ircd):
+        self.ircd = ircd
+
+    def actions(self):
+        return [ ("welcome", 1, self.autoJoinChannels) ]
+
+    def autoJoinChannels(self, user):
+        for chanName in self.ircd.config.getWithDefault("client_join_on_connect", []):
+            if chanName[0] != "#":
+                chanName = "#{}".format(chanName)
+            if chanName in self.ircd.channels:
+                channel = self.ircd.channels[chanName]
+            else:
+                channel = IRCChannel(self.ircd, chanName)
+            user.joinChannel(channel)
+
+autoJoin = AutoJoin()


### PR DESCRIPTION
Finished another module. I've tested it over on heufneutje.net and it works. I'm also pretty sure that by handling the JOIN command rather than calling `user.join()` directly, all of the restrictions like ban lists are handled correctly.

(By the way, I need to stop doing these at work and get my actual work done :P)
