### PR TITLE
Implement the usermodes on connect module

### DIFF
--- a/txircd/modules/extra/conn_umodes.py
+++ b/txircd/modules/extra/conn_umodes.py
@@ -1,0 +1,25 @@
+from twisted.plugin import IPlugin
+from txircd.module_interface import IModuleData, ModuleData
+from zope.interface import implements
+
+class AutoUserModes(ModuleData):
+    implements(IPlugin, IModuleData)
+
+    name = "AutoUserModes"
+
+    def hookIRCd(self, ircd):
+        self.ircd = ircd
+
+    def actions(self):
+        return [ ("welcome", 1, self.autoSetUserModes) ]
+
+    def autoSetUserModes(self, user):
+        try:
+            modes = self.ircd.config["client_umodes_on_connect"]
+            params = modes.split()
+            modes = params.pop(0)
+            user.setModes(self.ircd.serverID, modes, params)
+        except KeyError:
+            pass # No umodes defined. No action required.
+
+autoUserModes = AutoUserModes()


### PR DESCRIPTION
Seems to work fine. The only issue this might have is that it bypasses the manual setting of +o. I could either catch this or we can assume server admins aren't stupid enough to actually put +o in there.
