### PR TITLE
Fix linter warnings

### DIFF
--- a/txircd/modules/rfc/cmd_join.py
+++ b/txircd/modules/rfc/cmd_join.py
@@ -4,7 +4,6 @@ from txircd.channel import IRCChannel
 from txircd.module_interface import Command, ICommand, IModuleData, ModuleData
 from txircd.utils import timestamp
 from zope.interface import implements
-from datetime import datetime
 
 class JoinCommand(ModuleData):
     implements(IPlugin, IModuleData)

--- a/txircd/modules/server/metadata.py
+++ b/txircd/modules/server/metadata.py
@@ -24,7 +24,7 @@ class ServerMetadata(ModuleData, Command):
         serverPrefix = fromServer.serverID if fromServer else self.ircd.serverID
         for server in self.ircd.servers.itervalues():
             if server.nextClosest == self.ircd.serverID and server != fromServer:
-                if valueParam is None:
+                if value is None:
                     server.sendMessage("METADATA", targetID, targetTime, namespace, key, prefix=serverPrefix)
                 else:
                     server.sendMessage("METADATA", targetID, targetTime, namespace, key, ":{}".format(value), prefix=serverPrefix)


### PR DESCRIPTION
- An unused import
- A mistyped variable
