### PR TITLE
Implement the WhoisAccount module

### DIFF
--- a/txircd/modules/extra/whoisaccount.py
+++ b/txircd/modules/extra/whoisaccount.py
@@ -1,0 +1,20 @@
+from twisted.plugin import IPlugin
+from twisted.words.protocols import irc
+from txircd.module_interface import IModuleData, ModuleData
+from zope.interface import implements
+
+irc.RPL_WHOISACCOUNT = "330"
+
+class WhoisAccount(ModuleData):
+    implements(IPlugin, IModuleData)
+
+    name = "WhoisAccount"
+
+    def actions(self):
+        return [ ("extrawhois", 1, self.whoisAccountName) ]
+
+    def whoisAccountName(self, user, targetUser):
+        if "accountname" in targetUser.metadata["ext"]:
+            user.sendMessage(irc.RPL_WHOISACCOUNT, targetUser.nick, targetUser.metadata["ext"]["accountname"], ":is logged in as")
+
+whoisAccount = WhoisAccount()


### PR DESCRIPTION
Since it's in the metadata, we might as well use it. Technically this could be integrated into the NickServ module, but I like having it separate so that it's there when we eventually do standalone services.
