### PR TITLE
Add ratelimit module

### DIFF
--- a/txircd/modules/core/ratelimit.py
+++ b/txircd/modules/core/ratelimit.py
@@ -19,7 +19,7 @@ class RateLimit(ModuleData):
     def getConfig(self):
         config = {
             "limit": 60, # stop accepting commands after this many
-            "kill_limit": 1000, # disconnect the user after this many
+            "kill_limit": 500, # disconnect the user after this many
             "interval": 60,
         }
         config.update(self.ircd.config.getWithDefault("ratelimit", {}))


### PR DESCRIPTION
This module prevents too many commands from being processed per period.
It is conservative in that it will inform the user and not immediately disconnect them, unless they continue to flood past a higher limit (this lets you potentially set the limit quite low if you have to, without making the server unusable). The ignore limit, the kill limit and the time interval are all configurable.
