### PR TITLE
Add the CHANTYPES token to ISUPPORT

### DIFF
--- a/txircd/ircd.py
+++ b/txircd/ircd.py
@@ -38,6 +38,7 @@ class IRCd(Service):
         self.name = None
         self.isupport_tokens = {
             "CHANNELLEN": 64,
+            "CHANTYPES": "#",
             "CASEMAPPING": "rfc1459",
             "MODES": 20,
             "NICKLEN": 32,


### PR DESCRIPTION
This token was apparently missing and I didn't notice it until now.
