### PR TITLE
Fix the channel limit mode

### DIFF
--- a/txircd/modules/rfc/cmode_l.py
+++ b/txircd/modules/rfc/cmode_l.py
@@ -27,7 +27,7 @@ class LimitMode(ModuleData, Mode):
     
     def checkSet(self, channel, param):
         if param.isdigit():
-            return param
+            return [param]
         return None
     
     def apply(self, actionType, channel, param, alsoChannel, user):


### PR DESCRIPTION
This fixes a bug where every digit was handled as a separate parameter, causing "MODE #channel +l 10" to turn into "MODE #channel +ll 1 0"
