### PR TITLE
Don't try to list statuses if the WHO mask is not a channel

### DIFF
--- a/txircd/modules/rfc/cmd_who.py
+++ b/txircd/modules/rfc/cmd_who.py
@@ -63,7 +63,7 @@ class WhoCommand(ModuleData, Command):
             serverName = server.name
             isOper = self.ircd.runActionUntilValue("userhasoperpermission", targetUser, "who-display", users=[user])
             isAway = "away" in targetUser.metadata["ext"]
-            status = self.ircd.runActionUntilValue("channelstatuses", channel, targetUser, users=[targetUser], channels=[channel])
+            status = self.ircd.runActionUntilValue("channelstatuses", channel, targetUser, users=[targetUser], channels=[channel]) if channel else ""
             hopcount = 0
             if user.uuid[:3] != self.ircd.serverID:
                 countingServer = server


### PR DESCRIPTION
This fixes a disconnect that occurs if you try to request WHO data for a mask that's not a channel. Looking at the commit history this apparently broke when we replaced the hardcoded status display with an action.
