### PR TITLE
Use the server name instead of the network name for the MOTD

### DIFF
--- a/txircd/modules/rfc/cmd_motd.py
+++ b/txircd/modules/rfc/cmd_motd.py
@@ -44,7 +44,7 @@ class MessageOfTheDay(ModuleData, Command):
         if not self.motd:
             user.sendMessage(irc.ERR_NOMOTD, ":Message of the day file is missing.")
         else:
-            user.sendMessage(irc.RPL_MOTDSTART, ":{} Message of the Day".format(self.ircd.config["network_name"]))
+            user.sendMessage(irc.RPL_MOTDSTART, ":{} Message of the Day".format(self.ircd.name))
             for line in self.motd:
                 user.sendMessage(irc.RPL_MOTD, ":{}".format(line))
             user.sendMessage(irc.RPL_ENDOFMOTD, ":End of message of the day")


### PR DESCRIPTION
The RFC says the server name should be used here, which is also what all IRCd implementations I know do as well. (It also makes more sense logically because different servers across the network can have different MOTDs)
