### PR TITLE
X:line tweaks

### DIFF
--- a/txircd/modules/core/bans_gline.py
+++ b/txircd/modules/core/bans_gline.py
@@ -101,7 +101,10 @@ class UserGLine(Command):
 					badUsers.append((checkUser, reason))
 			for badUser in badUsers:
 				self.module.killUser(*badUser)
-			user.sendMessage("NOTICE", "*** G:line for {} has been set.".format(banmask))
+			if data["duration"] > 0:
+				user.sendMessage("NOTICE", "*** Timed g:line for {} has been set, to expire in {} seconds.".format(banmask, data["duration"]))
+			else:
+				user.sendMessage("NOTICE", "*** Permanent g:line for {} has been set.".format(banmask))
 			return True
 		if not self.module.delLine(banmask):
 			user.sendMessage("NOTICE", "*** G:Line for {} doesn't exist.".format(banmask))

--- a/txircd/modules/core/bans_gline.py
+++ b/txircd/modules/core/bans_gline.py
@@ -33,7 +33,7 @@ class GLine(ModuleData, XLineBase):
 		return fnmatchcase(userMask, banMask)
 	
 	def killUser(self, user, reason):
-		user.sendMessage("NOTICE", self.ircd.config.get("client_ban_msg", "You're banned! Email abuse@example.com for assistance."))
+		user.sendMessage(irc.ERR_YOUREBANNEDCREEP, self.ircd.config.get("client_ban_msg", "You're banned! Email abuse@example.com for assistance."))
 		user.disconnect("G:Lined: {}".format(banReason))
 	
 	def checkLines(self, user):

--- a/txircd/modules/core/bans_gline.py
+++ b/txircd/modules/core/bans_gline.py
@@ -34,7 +34,7 @@ class GLine(ModuleData, XLineBase):
 	
 	def killUser(self, user, reason):
 		user.sendMessage(irc.ERR_YOUREBANNEDCREEP, self.ircd.config.get("client_ban_msg", "You're banned! Email abuse@example.com for assistance."))
-		user.disconnect("G:Lined: {}".format(banReason))
+		user.disconnect("G:Lined: {}".format(reason))
 	
 	def checkLines(self, user):
 		banReason = self.matchUser(user)
@@ -62,7 +62,7 @@ class GLine(ModuleData, XLineBase):
 
 class UserGLine(Command):
 	implements(ICommand)
-	
+
 	def __init__(self, module):
 		self.module = module
 	
@@ -128,7 +128,7 @@ class ServerDelGLine(Command):
 		self.module = module
 	
 	def parseParams(self, server, params, prefix, tags):
-		return self.module.handleServerDelParams(server, param, prefix, tags)
+		return self.module.handleServerDelParams(server, params, prefix, tags)
 	
 	def execute(self, server, data):
 		return self.module.executeServerDelCommand(server, data)

--- a/txircd/modules/core/bans_kline.py
+++ b/txircd/modules/core/bans_kline.py
@@ -30,7 +30,7 @@ class KLine(ModuleData, Command, XLineBase):
 		return fnmatchcase(userMask, banMask)
 	
 	def killUser(self, user, reason):
-		user.sendMessage("NOTICE", self.ircd.config.get("client_ban_msg", "You're banned! Email abuse@example.com for assistance."))
+		user.sendMessage(irc.ERR_YOUREBANNEDCREEP, self.ircd.config.get("client_ban_msg", "You're banned! Email abuse@example.com for assistance."))
 		user.disconnect("K:Lined: {}".format(banReason))
 	
 	def checkLines(self, user):

--- a/txircd/modules/core/bans_kline.py
+++ b/txircd/modules/core/bans_kline.py
@@ -31,7 +31,7 @@ class KLine(ModuleData, Command, XLineBase):
 	
 	def killUser(self, user, reason):
 		user.sendMessage(irc.ERR_YOUREBANNEDCREEP, self.ircd.config.get("client_ban_msg", "You're banned! Email abuse@example.com for assistance."))
-		user.disconnect("K:Lined: {}".format(banReason))
+		user.disconnect("K:Lined: {}".format(reason))
 	
 	def checkLines(self, user):
 		banReason = self.matchUser(user)

--- a/txircd/modules/core/bans_kline.py
+++ b/txircd/modules/core/bans_kline.py
@@ -91,7 +91,10 @@ class KLine(ModuleData, Command, XLineBase):
 					badUsers.append((checkUser, reason))
 			for badUser in badUsers:
 				self.killUser(*badUser)
-			user.sendMessage("NOTICE", "*** K:line for {} has been set.".format(banmask))
+			if data["duration"] > 0:
+				user.sendMessage("NOTICE", "*** Timed k:line for {} has been set, to expire in {} seconds.".format(banmask, data["duration"]))
+			else:
+				user.sendMessage("NOTICE", "*** Permanent k:line for {} has been set.".format(banmask))
 			return True
 		if not self.delLine(banmask):
 			user.sendMessage("NOTICE", "*** K:Line for {} doesn't exist.".format(banmask))

--- a/txircd/modules/core/bans_qline.py
+++ b/txircd/modules/core/bans_qline.py
@@ -48,7 +48,8 @@ class QLine(ModuleData, XLineBase):
 	
 	def checkNick(self, user, data):
 		newNick = data["nick"]
-		if self.matchUser(user, { "newnick": newNick }):
+		reason = self.matchUser(user, { "newnick": newNick })
+		if reason:
 			user.sendMessage("NOTICE", "The nickname you chose was invalid. ({})".format(reason))
 			return False
 		return True
@@ -60,8 +61,8 @@ class QLine(ModuleData, XLineBase):
 		return None
 	
 	def checkStatsType(self, typeName):
-		if typeName == "Z":
-			return "ZLINES"
+		if typeName == "Q":
+			return "QLINES"
 		return None
 	
 	def listStats(self):

--- a/txircd/modules/core/bans_qline.py
+++ b/txircd/modules/core/bans_qline.py
@@ -101,7 +101,10 @@ class UserQLine(Command):
 				reason = self.module.matchUser(checkUser)
 				if reason:
 					self.module.changeNick(checkUser, reason, True)
-			user.sendMessage("NOTICE", "*** Q:Line for {} has been set.".format(banmask))
+			if data["duration"] > 0:
+				user.sendMessage("NOTICE", "*** Timed q:line for {} has been set, to expire in {} seconds.".format(banmask, data["duration"]))
+			else:
+				user.sendMessage("NOTICE", "*** Permanent q:line for {} has been set.".format(banmask))
 			return True
 		if not self.module.delLine(banmask):
 			user.sendMessage("NOTICE", "*** Q:Line for {} doesn't exist.".format(banmask))

--- a/txircd/modules/core/bans_zline.py
+++ b/txircd/modules/core/bans_zline.py
@@ -41,7 +41,7 @@ class ZLine(ModuleData, XLineBase):
 	
 	def killUser(self, user, reason):
 		user.sendMessage(irc.ERR_YOUREBANNEDCREEP, self.ircd.config.get("client_ban_msg", "You're banned! Email abuse@example.com for assistance."))
-		user.disconnect("Z:Lined: {}".format(banReason))
+		user.disconnect("Z:Lined: {}".format(reason))
 	
 	def checkLines(self, user):
 		reason = self.matchUser(user)

--- a/txircd/modules/core/bans_zline.py
+++ b/txircd/modules/core/bans_zline.py
@@ -40,7 +40,7 @@ class ZLine(ModuleData, XLineBase):
 		return mask
 	
 	def killUser(self, user, reason):
-		user.sendMessage("NOTICE", self.ircd.config.get("client_ban_msg", "You're banned! Email abuse@example.com for assistance."))
+		user.sendMessage(irc.ERR_YOUREBANNEDCREEP, self.ircd.config.get("client_ban_msg", "You're banned! Email abuse@example.com for assistance."))
 		user.disconnect("Z:Lined: {}".format(banReason))
 	
 	def checkLines(self, user):

--- a/txircd/modules/core/bans_zline.py
+++ b/txircd/modules/core/bans_zline.py
@@ -103,7 +103,10 @@ class UserZLine(Command):
 					badUsers.append((checkUser, reason))
 			for badUser in badUsers:
 				self.module.killUser(*badUser)
-			user.sendMessage("NOTICE", "*** Z:Line for {} has been set.".format(banmask))
+			if data["duration"] > 0:
+				user.sendMessage("NOTICE", "*** Timed z:line for {} has been set, to expire in {} seconds.".format(banmask, data["duration"]))
+			else:
+				user.sendMessage("NOTICE", "*** Permanent z:line for {} has been set.".format(banmask))
 			return True
 		if not self.module.delLine(data["mask"]):
 			user.sendMessage("NOTICE", "*** Z:Line for {} doesn't exist.".format(banmask))

--- a/txircd/modules/lib/xlinebase.py
+++ b/txircd/modules/lib/xlinebase.py
@@ -11,7 +11,7 @@ class XLineBase(object):
 		self.expireLines()
 		for lineData in self.ircd.storage["xlines"][self.lineType]:
 			mask = lineData["mask"]
-			if self.checkUserMatch(user, mask, data) and self.runComboActionUntilValue((("verifyxlinematch-{}".format(self.lineType), user, mask, data), ("verifyxlinematch", self.lineType, user, mask, data)), users=[user]) is not False:
+			if self.checkUserMatch(user, mask, data) and self.ircd.runComboActionUntilValue((("verifyxlinematch-{}".format(self.lineType), user, mask, data), ("verifyxlinematch", self.lineType, user, mask, data)), users=[user]) is not False:
 				return lineData["reason"]
 		return None
 	


### PR DESCRIPTION
I made a few changes to the things you've done with the new x:lines. First of all, I fixed a number of typos that snuck in (did you write this code late at night? :P) and I also fixed a numeric that we got wrong and have been getting wrong on every previous version of txircd, according to the RFC.

Lastly I improved the verbosity of the x:line setting messages a bit so that they state the duration again and whether or not they are permament. Just to make sure an oper doesn't accidentally set an x:line with the wrong duration.

There's a problem with the x:line lib you wrote that I sent you a tell about on IRC, but I didn't fix it. The API is kind of your thing so I didn't want to mess with it too much. :P