### PR TITLE
Fix a handful of bugs

### DIFF
--- a/txircd/channel.py
+++ b/txircd/channel.py
@@ -100,7 +100,7 @@ class IRCChannel(object):
 		oldData = None
 		if key in self._metadata:
 			oldData = self._metadata[key]
-		if setByUser and not oldData[3]:
+		if setByUser and oldData and not oldData[3]:
 			return False
 		if setByUser and self.ircd.runActionUntilValue("usercansetmetadata", key, users=[self]) is False:
 			return False
@@ -110,7 +110,8 @@ class IRCChannel(object):
 			return False
 		else:
 			self._metadata[key] = (key, value, visibility, setByUser)
-		self.ircd.runActionStandard("channelmetadataupdate", self, key, oldData[1], value, visibility, setByUser, fromServer, channels=[self])
+		oldValue = oldData[1] if oldData else None
+		self.ircd.runActionStandard("channelmetadataupdate", self, key, oldValue, value, visibility, setByUser, fromServer, channels=[self])
 		return True
 	
 	def setModes(self, modes, defaultSource):

--- a/txircd/modules/core/bans_eline.py
+++ b/txircd/modules/core/bans_eline.py
@@ -67,8 +67,8 @@ class UserELine(Command):
 			return None
 		
 		banmask = params[0]
-		if banmask in self.ircd.userNicks:
-			targetUser = self.ircd.users[self.ircd.userNicks[banmask]]
+		if banmask in self.module.ircd.userNicks:
+			targetUser = self.module.ircd.users[self.module.ircd.userNicks[banmask]]
 			banmask = "{}@{}".format(targetUser.ident, targetUser.host)
 		else:
 			if "@" not in banmask:
@@ -80,7 +80,7 @@ class UserELine(Command):
 			}
 		return {
 			"mask": banmask,
-			"duration": durationToSeconds,
+			"duration": durationToSeconds(params[1]),
 			"reason": " ".format(params[2:])
 		}
 	
@@ -90,7 +90,6 @@ class UserELine(Command):
 			if not self.module.addLine(banmask, now(), data["duration"], user.hostmask(), data["reason"]):
 				user.sendMessage("NOTICE", "*** E:Line for {} is already set.".format(banmask))
 				return True
-			
 			if data["duration"] > 0:
 				user.sendMessage("NOTICE", "*** Timed e:line for {} has been set, to expire in {} seconds.".format(banmask, data["duration"]))
 			else:

--- a/txircd/modules/core/bans_qline.py
+++ b/txircd/modules/core/bans_qline.py
@@ -49,6 +49,7 @@ class QLine(ModuleData, XLineBase):
 		return True
 	
 	def checkNick(self, user, data):
+		self.expireLines()
 		newNick = data["nick"]
 		reason = self.matchUser(user, { "newnick": newNick })
 		if reason:

--- a/txircd/modules/extra/channelopaccess.py
+++ b/txircd/modules/extra/channelopaccess.py
@@ -46,6 +46,6 @@ class ChannelOpAccess(ModuleData, Mode):
 		if status not in self.ircd.channelStatuses:
 			return False # For security, we'll favor those that were restricting permissions while a certain status was loaded.
 		level = self.ircd.channelStatuses[status][1]
-		return (channel.userRank(user) >= level)
+		return channel.userRank(user) >= level
 
 chanAccess = ChannelOpAccess()

--- a/txircd/modules/lib/xlinebase.py
+++ b/txircd/modules/lib/xlinebase.py
@@ -68,7 +68,7 @@ class XLineBase(object):
 		lines = self.ircd.storage["xlines"][self.lineType]
 		for lineData in lines:
 			duration = timedelta(seconds=lineData["duration"])
-			expireTime = currentTime + duration
+			expireTime = lineData["created"] + duration
 			if expireTime < currentTime:
 				expiredLines.append(lineData)
 		for lineData in expiredLines:

--- a/txircd/modules/lib/xlinebase.py
+++ b/txircd/modules/lib/xlinebase.py
@@ -69,7 +69,7 @@ class XLineBase(object):
 		for lineData in lines:
 			duration = timedelta(seconds=lineData["duration"])
 			expireTime = lineData["created"] + duration
-			if expireTime < currentTime:
+			if expireTime < currentTime and lineData["duration"] > 0:
 				expiredLines.append(lineData)
 		for lineData in expiredLines:
 			lines.remove(lineData)

--- a/txircd/modules/rfc/mech_oper.py
+++ b/txircd/modules/rfc/mech_oper.py
@@ -137,7 +137,7 @@ class UserOper(Command):
 			log.msg("Failed OPER attempt from {} ({})".format(user.nick, reason), logLevel=logging.WARNING)
 			self.ircd.runActionStandard("operfail", user, reason)
 			return
-		self.ircd.runActionStandard("oper", user, reason)
+		self.ircd.runActionStandard("oper", user)
 
 class ServerOper(Command):
 	implements(ICommand)

--- a/txircd/user.py
+++ b/txircd/user.py
@@ -349,7 +349,7 @@ class IRCUser(IRCBase):
 		oldData = None
 		if key in self._metadata:
 			oldData = self._metadata[key]
-		if setByUser and not oldData[3]:
+		if setByUser and oldData and not oldData[3]:
 			return False
 		if setByUser and self.ircd.runActionUntilValue("usercansetmetadata", key, users=[self]) is False:
 			return False
@@ -360,7 +360,8 @@ class IRCUser(IRCBase):
 			return False
 		else:
 			self._metadata[key] = (key, value, visibility, setByUser)
-		self.ircd.runActionStandard("usermetadataupdate", self, key, oldData[1], value, visibility, setByUser, fromServer, users=[self])
+		oldValue = oldData[1] if oldData else None
+		self.ircd.runActionStandard("usermetadataupdate", self, key, oldValue, value, visibility, setByUser, fromServer, users=[self])
 		return True
 	
 	def joinChannel(self, channel, override = False):


### PR DESCRIPTION
There's a number of things that I fixed.

There's a few things I changed that I'm not sure about and a few things that seem broken, but I'm not sure how to fix.
- Stats seem to be broken. /stats elines returns nothing despite having a permanent e:line set. I didn't fix this one because I have no clue how the new combo actions work and it seems to be related to those.
- My metadata fix might not be exactly how it's supposed to work. I think it should be but I'll leave that one up to you.
- I added a thing to make xlines with a duration of 0 permanent again. This wasn't the case before this PR. Despite this being how it worked in 0.3, I feel like there should be a nicer solution to this.
- E:lines currently protect an oper against z:lines. I'm not sure if this is intended behaviour, because z:lines are normally checked before e:lines and shouldn't be affected by an e:line.