### PR TITLE
Limit changes and config validation

### DIFF
--- a/txircd/channel.py
+++ b/txircd/channel.py
@@ -5,7 +5,7 @@ from weakref import WeakKeyDictionary
 class IRCChannel(object):
 	def __init__(self, ircd, name):
 		if not isValidChannelName(name):
-			raise InvalidChannelName
+			raise InvalidChannelNameError
 		self.ircd = ircd
 		self.name = name[:self.ircd.config.get("channel_name_length", 64)]
 		self.users = WeakKeyDictionary()
@@ -444,6 +444,6 @@ class IRCChannel(object):
 			return 0
 		return self.ircd.channelStatuses[status[0]][1]
 
-class InvalidChannelName(Exception):
+class InvalidChannelNameError(Exception):
 	def __str__(self):
 		return "Invalid character in channel name"

--- a/txircd/channel.py
+++ b/txircd/channel.py
@@ -7,7 +7,7 @@ class IRCChannel(object):
 		if not isValidChannelName(name):
 			raise InvalidChannelName
 		self.ircd = ircd
-		self.name = name[:self.ircd.config.get("channel_length", 64)]
+		self.name = name[:self.ircd.config.get("channel_name_length", 64)]
 		self.users = WeakKeyDictionary()
 		self.modes = {}
 		self.existedSince = now()
@@ -295,7 +295,7 @@ class IRCChannel(object):
 							continue
 						parameter = targetUser.uuid
 					elif modeType == ModeType.List:
-						if mode in self.modes and len(self.modes[mode]) > self.ircd.config.get("channel_list_limit", 128):
+						if mode in self.modes and len(self.modes[mode]) > self.ircd.config.get("channel_listmode_limit", 128):
 							user.sendMessage(irc.ERR_BANLISTFULL, self.name, parameter, "Channel +{} list is full".format(mode))
 							continue
 				else:
@@ -345,7 +345,7 @@ class IRCChannel(object):
 				return True
 			if modeType == ModeType.List:
 				if mode in self.modes:
-					if len(self.modes[mode]) > self.ircd.config.get("channel_list_limit", 128):
+					if len(self.modes[mode]) > self.ircd.config.get("channel_listmode_limit", 128):
 						return False
 					for paramData in self.modes[mode]:
 						if parameter == paramData[0]:

--- a/txircd/channel.py
+++ b/txircd/channel.py
@@ -7,7 +7,7 @@ class IRCChannel(object):
 		if not isValidChannelName(name):
 			raise InvalidChannelName
 		self.ircd = ircd
-		self.name = name[:64]
+		self.name = name[:self.ircd.config.get("channel_length", 64)]
 		self.users = WeakKeyDictionary()
 		self.modes = {}
 		self.existedSince = now()
@@ -241,7 +241,7 @@ class IRCChannel(object):
 		setBy = self._sourceName(user.uuid)
 		setTime = now()
 		for mode in modes:
-			if len(changes) >= 20:
+			if len(changes) >= self.ircd.config.get("modes_per_line", 20):
 				break
 			if mode == "+":
 				adding = True
@@ -275,7 +275,7 @@ class IRCChannel(object):
 				continue
 			
 			for parameter in paramList:
-				if len(changes) >= 20:
+				if len(changes) >= self.ircd.config.get("modes_per_line", 20):
 					break
 				if not override and self.ircd.runActionUntilValue("modepermission-channel-{}".format(mode), self, user, adding, parameter, users=[user], channels=[self]) is False:
 					continue

--- a/txircd/ircd.py
+++ b/txircd/ircd.py
@@ -465,8 +465,10 @@ class IRCd(Service):
 	def generateISupportList(self):
 		isupport = self.isupport_tokens.copy()
 		statusSymbolOrder = "".join([self.channelStatuses[status][0] for status in self.channelStatusOrder])
+		isupport["AWAYLEN"] = self.config.get("away_length", 200)
 		isupport["CHANMODES"] = ",".join(["".join(modes) for modes in self.channelModes])
 		isupport["CHANNELEN"] = self.config.get("channel_length", 64)
+		isupport["KICKLEN"] = self.config.get("kick_length", 255)
 		isupport["MODES"] = self.config.get("modes_per_line", 20)
 		isupport["NETWORK"] = self.config["network_name"]
 		isupport["NICKLEN"] = self.config.get("nick_length", 32)

--- a/txircd/ircd.py
+++ b/txircd/ircd.py
@@ -611,17 +611,13 @@ class IRCd(Service):
 	def generateISupportList(self):
 		isupport = self.isupport_tokens.copy()
 		statusSymbolOrder = "".join([self.channelStatuses[status][0] for status in self.channelStatusOrder])
-		isupport["AWAYLEN"] = self.config.get("away_length", 200)
 		isupport["CHANMODES"] = ",".join(["".join(modes) for modes in self.channelModes])
 		isupport["CHANNELEN"] = self.config.get("channel_name_length", 64)
-		isupport["KICKLEN"] = self.config.get("kick_length", 255)
-		isupport["MODES"] = self.config.get("modes_per_line", 20)
 		isupport["NETWORK"] = self.config["network_name"]
-		isupport["NICKLEN"] = self.config.get("nick_length", 32)
 		isupport["PREFIX"] = "({}){}".format("".join(self.channelStatusOrder), statusSymbolOrder)
 		isupport["STATUSMSG"] = statusSymbolOrder
-		isupport["TOPICLEN"] = self.config.get("topic_length", 326)
 		isupport["USERMODES"] = ",".join(["".join(modes) for modes in self.userModes])
+		self.runActionStandard("buildisupport", isupport)
 		isupportList = []
 		for key, val in isupport.iteritems():
 			if val is None:

--- a/txircd/ircd.py
+++ b/txircd/ircd.py
@@ -40,12 +40,8 @@ class IRCd(Service):
 		self.serverID = None
 		self.name = None
 		self.isupport_tokens = {
-			"CHANNELLEN": 64,
-			"CHANTYPES": "#",
 			"CASEMAPPING": "strict-rfc1459",
-			"MODES": 20,
-			"NICKLEN": 32,
-			"TOPICLEN": 328
+			"CHANTYPES": "#",
 		}
 		self._uid = self._genUID()
 		
@@ -470,10 +466,14 @@ class IRCd(Service):
 		isupport = self.isupport_tokens.copy()
 		statusSymbolOrder = "".join([self.channelStatuses[status][0] for status in self.channelStatusOrder])
 		isupport["CHANMODES"] = ",".join(["".join(modes) for modes in self.channelModes])
+		isupport["CHANNELEN"] = self.config.get("channel_length", 64)
+		isupport["MODES"] = self.config.get("modes_per_line", 20)
+		isupport["NETWORK"] = self.config["network_name"]
+		isupport["NICKLEN"] = self.config.get("nick_length", 32)
 		isupport["PREFIX"] = "({}){}".format("".join(self.channelStatusOrder), statusSymbolOrder)
 		isupport["STATUSMSG"] = statusSymbolOrder
+		isupport["TOPICLEN"] = self.config.get("topic_length", 326)
 		isupport["USERMODES"] = ",".join(["".join(modes) for modes in self.userModes])
-		isupport["NETWORK"] = self.config["network_name"]
 		isupportList = []
 		for key, val in isupport.iteritems():
 			if val is None:

--- a/txircd/module_interface.py
+++ b/txircd/module_interface.py
@@ -108,6 +108,13 @@ class IModuleData(Interface):
 		handled by this module.
 		"""
 
+	def verifyConfig(config):
+		"""
+		Called when the module is loaded and when the server is rehashed.  Should check all
+		configuration values defined by this module and either adjust them in the configuration
+		or raise a ConfigValidationError when an invalid value is defined.
+		"""
+
 class ModuleData(object):
 	requiredOnAllServers = False
 	multipleModulesForServers = False
@@ -141,6 +148,9 @@ class ModuleData(object):
 		pass
 	
 	def fullUnload(self):
+		pass
+
+	def verifyConfig(self, config):
 		pass
 
 

--- a/txircd/modules/core/bans_gline.py
+++ b/txircd/modules/core/bans_gline.py
@@ -1,5 +1,6 @@
 from twisted.plugin import IPlugin
 from twisted.words.protocols import irc
+from txircd.config import ConfigValidationError
 from txircd.module_interface import Command, ICommand, IModuleData, ModuleData
 from txircd.modules.xlinebase import XLineBase
 from txircd.utils import durationToSeconds, ircLower, now
@@ -28,6 +29,10 @@ class GLine(ModuleData, XLineBase):
 	
 	def load(self):
 		self.initializeLineStorage()
+
+	def verifyConfig(self, config):
+		if "client_ban_msg" in config and not isinstance(config["client_ban_msg"], basestring):
+			raise ConfigValidationError("client_ban_msg", "value must be a string")
 	
 	def checkUserMatch(self, user, mask, data):
 		banMask = self.normalizeMask(mask)

--- a/txircd/modules/core/bans_kline.py
+++ b/txircd/modules/core/bans_kline.py
@@ -1,5 +1,6 @@
 from twisted.plugin import IPlugin
 from twisted.words.protocols import irc
+from txircd.config import ConfigValidationError
 from txircd.module_interface import Command, ICommand, IModuleData, ModuleData
 from txircd.modules.xlinebase import XLineBase
 from txircd.utils import durationToSeconds, ircLower, now
@@ -25,6 +26,10 @@ class KLine(ModuleData, Command, XLineBase):
 	
 	def load(self):
 		self.initializeLineStorage()
+
+	def verifyConfig(self, config):
+		if "client_ban_msg" in config and not isinstance(config["client_ban_msg"], basestring):
+			raise ConfigValidationError("client_ban_msg", "value must be a string")
 	
 	def checkUserMatch(self, user, mask, data):
 		banMask = self.normalizeMask(mask)

--- a/txircd/modules/core/bans_qline.py
+++ b/txircd/modules/core/bans_qline.py
@@ -1,5 +1,6 @@
 from twisted.plugin import IPlugin
 from twisted.words.protocols import irc
+from txircd.config import ConfigValidationError
 from txircd.module_interface import Command, ICommand, IModuleData, ModuleData
 from txircd.modules.xlinebase import XLineBase
 from txircd.utils import durationToSeconds, ircLower, now
@@ -29,6 +30,10 @@ class QLine(ModuleData, XLineBase):
 	
 	def load(self):
 		self.initializeLineStorage()
+
+	def verifyConfig(self, config):
+		if "client_ban_msg" in config and not isinstance(config["client_ban_msg"], basestring):
+			raise ConfigValidationError("client_ban_msg", "value must be a string")
 	
 	def checkUserMatch(self, user, mask, data):
 		if data and "newnick" in data:

--- a/txircd/modules/core/bans_zline.py
+++ b/txircd/modules/core/bans_zline.py
@@ -1,5 +1,6 @@
 from twisted.plugin import IPlugin
 from twisted.words.protocols import irc
+from txircd.config import ConfigValidationError
 from txircd.module_interface import Command, ICommand, IModuleData, ModuleData
 from txircd.modules.xlinebase import XLineBase
 from txircd.utils import durationToSeconds, now
@@ -29,6 +30,10 @@ class ZLine(ModuleData, XLineBase):
 	
 	def load(self):
 		self.initializeLineStorage()
+
+	def verifyConfig(self, config):
+		if "client_ban_msg" in config and not isinstance(config["client_ban_msg"], basestring):
+			raise ConfigValidationError("client_ban_msg", "value must be a string")
 	
 	def checkUserMatch(self, user, mask, data):
 		return fnmatchcase(user.ip, mask)

--- a/txircd/modules/core/channel_defaultmodes.py
+++ b/txircd/modules/core/channel_defaultmodes.py
@@ -1,4 +1,5 @@
 from twisted.plugin import IPlugin
+from txircd.config import ConfigValidationError
 from txircd.module_interface import IModuleData, ModuleData
 from txircd.utils import ModeType
 from zope.interface import implements
@@ -11,10 +12,13 @@ class DefaultModes(ModuleData):
 	
 	def actions(self):
 		return [ ("channelcreate", 110, self.setDefaults) ]
+
+	def verifyConfig(self, config):
+		if "channel_default_modes" in config and not isinstance("channel_default_modes", basestring):
+			raise ConfigValidationError("channel_default_modes", "value must be a string of mode letters")
 	
 	def setDefaults(self, channel, user):
 		modes = self.ircd.config.get("channel_default_modes", "ont")
-		statusModes = set()
 		params = modes.split(" ")
 		modeList = list(params.pop(0))
 		settingModes = []

--- a/txircd/modules/core/channellevel.py
+++ b/txircd/modules/core/channellevel.py
@@ -1,4 +1,5 @@
 from twisted.plugin import IPlugin
+from txircd.config import ConfigValidationError
 from txircd.module_interface import IModuleData, ModuleData
 from zope.interface import implements
 
@@ -11,6 +12,12 @@ class ChannelLevel(ModuleData):
 	def actions(self):
 		return [ ("checkchannellevel", 1, self.levelCheck),
 		         ("checkexemptchanops", 1, self.exemptCheck) ]
+
+	def verifyConfig(self, config):
+		if "channel_minimum_level" in config and not isinstance("channel_minimum_level", dict):
+			raise ConfigValidationError("channel_minimum_level", "value must be a dictionary")
+		if "channel_exempt_level" in config and not isinstance("channel_exempt_level", dict):
+			raise ConfigValidationError("channel_exempt_level", "value must be a dictionary")
 	
 	def minLevelFromConfig(self, configKey, checkType, defaultLevel):
 		configLevel = self.ircd.config.get(configKey, {}).get(checkType, defaultLevel)

--- a/txircd/modules/extra/cloaking.py
+++ b/txircd/modules/extra/cloaking.py
@@ -42,7 +42,7 @@ class HostCloaking(ModuleData, Mode):
 		# Cloak the first part of the host and leave the last segments alone.
 		hostmask = "{}-{}{}".format(self.cloakingPrefix, sha256(self.cloakingSalt + host[:index]).hexdigest()[:8], host[index:])
 		# This is very rare since we only leave up to 3 segments uncloaked, but make sure the end result isn't too long.
-		if len(hostmask) > 64:
+		if len(hostmask) > self.ircd.config.get("hostname_length", 64):
 			if isIPv6Address(ip):
 				return self.applyIPv6Cloak(ip)
 			else:

--- a/txircd/modules/extra/cloaking.py
+++ b/txircd/modules/extra/cloaking.py
@@ -1,7 +1,8 @@
 from twisted.internet.abstract import isIPAddress, isIPv6Address
 from twisted.plugin import IPlugin
+from txircd.config import ConfigValidationError
 from txircd.module_interface import IMode, IModuleData, Mode, ModuleData
-from txircd.utils import ModeType
+from txircd.utils import isValidHost, ModeType
 from zope.interface import implements
 from hashlib import sha256
 
@@ -19,6 +20,17 @@ class HostCloaking(ModuleData, Mode):
 	def actions(self):
 		return [ ("modeactioncheck-user-x-modechange-user-x", 1, self.modeChanged) ]
 
+	def verifyConfig(self, config):
+		if "cloaking_salt" in config:
+			if not isinstance(config["cloaking_salt"], basestring):
+				raise ConfigValidationError("cloaking_salt", "value must be a string")
+			if not config["cloaking_salt"]:
+				self.ircd.log.warn("No cloaking salt was found in the config. Host cloaks will be insecure!")
+		else:
+			self.ircd.log.warn("No cloaking salt was found in the config. Host cloaks will be insecure!")
+		if "cloaking_prefix" in config and not isValidHost(config["cloaking_prefix"]): # Make sure the prefix will not make the cloak an invalid hostname
+			raise ConfigValidationError("cloaking_prefix", "value must be a string and must not contain any invalid hostname characters")
+
 	def modeChanged(self, user, *params):
 		if user.uuid[:3] == self.ircd.serverID:
 			return True
@@ -32,7 +44,13 @@ class HostCloaking(ModuleData, Mode):
 			elif isIPAddress(userHost):
 				user.changeHost(self.applyIPv4Cloak(userHost))
 			else:
-				user.changeHost(self.applyHostCloak(userHost, user.ip))
+				if "." in user.host:
+					user.changeHost(self.applyHostCloak(userHost, user.ip))
+				else:
+					if isIPv6Address(user.ip):
+						return self.applyIPv6Cloak(user.ip)
+					else:
+						return self.applyIPv4Cloak(user.ip)
 		else:
 			user.resetHost()
 
@@ -40,7 +58,7 @@ class HostCloaking(ModuleData, Mode):
 		# Find the last segments of the hostname.
 		index = len(host[::-1].split(".", 3)[-1])
 		# Cloak the first part of the host and leave the last segments alone.
-		hostmask = "{}-{}{}".format(self.cloakingPrefix, sha256(self.cloakingSalt + host[:index]).hexdigest()[:8], host[index:])
+		hostmask = "{}-{}{}".format(self.ircd.config.get("cloaking_prefix", "txircd"), sha256(self.ircd.config.get("cloaking_salt", "") + host[:index]).hexdigest()[:8], host[index:])
 		# This is very rare since we only leave up to 3 segments uncloaked, but make sure the end result isn't too long.
 		if len(hostmask) > self.ircd.config.get("hostname_length", 64):
 			if isIPv6Address(ip):
@@ -56,7 +74,7 @@ class HostCloaking(ModuleData, Mode):
 		for i in range(len(pieces), 0, -1):
 			piecesGroup = pieces[:i]
 			piecesGroup.reverse()
-			hashedParts.append(sha256(self.cloakingSalt + "".join(piecesGroup)).hexdigest()[:8])
+			hashedParts.append(sha256(self.ircd.config.get("cloaking_salt", "") + "".join(piecesGroup)).hexdigest()[:8])
 		return "{}.IP".format(".".join(hashedParts))
 
 	def applyIPv6Cloak(self, ip):
@@ -78,18 +96,7 @@ class HostCloaking(ModuleData, Mode):
 		for i in range(len(pieces), 0, -1):
 			piecesGroup = pieces[:i]
 			piecesGroup.reverse()
-			hashedParts.append(sha256(self.cloakingSalt + "".join(piecesGroup)).hexdigest()[:5])
+			hashedParts.append(sha256(self.ircd.config.get("cloaking_salt", "") + "".join(piecesGroup)).hexdigest()[:5])
 		return "{}.IP".format(".".join(hashedParts))
-
-	def load(self):
-		self.rehash()
-
-	def rehash(self):
-		try:
-			self.cloakingSalt = self.ircd.config["cloaking_salt"]
-		except KeyError:
-			self.cloakingSalt = ""
-			self.ircd.log.warn("No cloaking salt was found in the config. Host cloaks will be insecure!")
-		self.cloakingPrefix = self.ircd.config.get("cloaking_prefix", "txircd")
 
 hostCloaking = HostCloaking()

--- a/txircd/modules/extra/conn_join.py
+++ b/txircd/modules/extra/conn_join.py
@@ -1,6 +1,8 @@
 from twisted.plugin import IPlugin
-from txircd.channel import InvalidChannelName, IRCChannel
+from txircd.channel import IRCChannel
+from txircd.config import ConfigValidationError
 from txircd.module_interface import IModuleData, ModuleData
+from txircd.utils import isValidChannelName
 from zope.interface import implements
 
 class AutoJoin(ModuleData):
@@ -11,6 +13,16 @@ class AutoJoin(ModuleData):
 	def actions(self):
 		return [ ("welcome", 1, self.autoJoinChannels) ]
 
+	def verifyConfig(self, config):
+		if "client_join_on_connect" in config:
+			if not isinstance(config["client_join_on_connect"], list):
+				raise ConfigValidationError("client_join_on_connect", "value must be a list")
+			for chanName in config["client_join_on_connect"]:
+				if chanName[0] != "#":
+					chanName = "#{}".format(chanName)
+				if not isValidChannelName(chanName):
+					raise ConfigValidationError("client_join_on_connect", "\"{}\" is an invalid channel name".format(chanName))
+
 	def autoJoinChannels(self, user):
 		for chanName in self.ircd.config.get("client_join_on_connect", []):
 			if chanName[0] != "#":
@@ -18,11 +30,7 @@ class AutoJoin(ModuleData):
 			if chanName in self.ircd.channels:
 				channel = self.ircd.channels[chanName]
 			else:
-				try:
-					channel = IRCChannel(self.ircd, chanName)
-				except InvalidChannelName:
-					self.ircd.log.warn("Invalid channel name {} in conn_join configuration".format(chanName))
-					continue
+				channel = IRCChannel(self.ircd, chanName)
 			user.joinChannel(channel)
 
 autoJoin = AutoJoin()

--- a/txircd/modules/extra/conn_umodes.py
+++ b/txircd/modules/extra/conn_umodes.py
@@ -1,4 +1,5 @@
 from twisted.plugin import IPlugin
+from txircd.config import ConfigValidationError
 from txircd.module_interface import IModuleData, ModuleData
 from txircd.utils import ModeType
 from zope.interface import implements
@@ -10,6 +11,11 @@ class AutoUserModes(ModuleData):
 
 	def actions(self):
 		return [ ("welcome", 50, self.autoSetUserModes) ]
+
+	def verifyConfig(self, config):
+		if "client_umodes_on_connect" in config:
+			if not isinstance(config["client_umodes_on_connect"], basestring):
+				raise ConfigValidationError("client_umodes_on_connect", "value must be a valid mode string")
 
 	def autoSetUserModes(self, user):
 		try:

--- a/txircd/modules/extra/customprefix.py
+++ b/txircd/modules/extra/customprefix.py
@@ -1,4 +1,5 @@
 from twisted.plugin import IPlugin
+from txircd.config import ConfigValidationError
 from txircd.module_interface import IMode, IModuleData, Mode, ModuleData
 from txircd.utils import ModeType
 from zope.interface import implements
@@ -13,14 +14,24 @@ class CustomPrefix(ModuleData, Mode):
 		modes = []
 		self.prefixes = self.ircd.config.get("custom_prefixes", { "h": { "level": 50, "char": "%" }, "a": { "level": 150, "char": "&" }, "q" : { "level": 200, "char": "~" } })
 		for prefix, prefixValue in self.prefixes.iteritems():
-			try:
-				statusLevel = int(prefixValue["level"])
-				modes.append((prefix, ModeType.Status, self, statusLevel, prefixValue["char"]))
-			except ValueError:
-				self.ircd.log.warn("Custom prefix {prefix} does not specify a valid level; skipping prefix", prefix=prefix)
-			except KeyError as e:
-				self.ircd.log.warn("Custom prefix {prefix} is missing {missingKey}; skipping prefix", prefix=prefix, missingKey=e)
+			modes.append((prefix, ModeType.Status, self, prefixValue["level"], prefixValue["char"]))
 		return modes
+
+	def verifyConfig(self, config):
+		if "custom_prefixes" in config:
+			if not isinstance("custom_prefixes", dict):
+				raise ConfigValidationError("custom_prefixes", "value must be a dictionary")
+			for prefix, prefixValue in config["custom_prefixes"]:
+				if len(prefix) != 1:
+					raise ConfigValidationError("custom_prefixes", "prefix value \"{}\" should be a mode character")
+				if "level" not in prefixValue:
+					raise ConfigValidationError("custom_prefixes", "value \"level\" for prefix \"{}\" is missing".format(prefix))
+				if "char" not in prefixValue:
+					raise ConfigValidationError("custom_prefixes", "value \"char\" for prefix \"{}\" is missing".format(prefix))
+				if not isinstance(prefixValue["level"], int):
+					raise ConfigValidationError("custom_prefixes", "prefix \"{}\" does not specify a valid level")
+				if not isinstance(prefixValue["char"], basestring) or len(prefixValue["char"]) != 1:
+					raise ConfigValidationError("custom_prefixes", "prefix \"{}\" does not specify a valid prefix character")
 
 	def checkSet(self, channel, param):
 		return param.split(",")

--- a/txircd/modules/extra/knock.py
+++ b/txircd/modules/extra/knock.py
@@ -1,5 +1,6 @@
 from twisted.plugin import IPlugin
 from twisted.words.protocols import irc
+from txircd.config import ConfigValidationError
 from txircd.module_interface import Command, ICommand, IMode, IModuleData, Mode, ModuleData
 from txircd.utils import ModeType, now, timestamp
 from zope.interface import implements
@@ -26,6 +27,10 @@ class Knock(ModuleData):
 
 	def channelModes(self):
 		return [ ("K", ModeType.NoParam, NoKnockMode()) ]
+
+	def verifyConfig(self, config):
+		if "knock_delay" in config and (not isinstance(config["knock_delay"], int) or config["knock_delay"] < 0):
+			raise ConfigValidationError("knock_delay", "invalid number")
 
 	def channelHasMode(self, channel, user, data):
 		if "K" in channel.modes:

--- a/txircd/modules/extra/ratelimit.py
+++ b/txircd/modules/extra/ratelimit.py
@@ -1,4 +1,5 @@
 from twisted.plugin import IPlugin
+from txircd.config import ConfigValidationError
 from txircd.module_interface import IModuleData, ModuleData
 from txircd.utils import now, timestamp
 from zope.interface import implements
@@ -10,6 +11,16 @@ class RateLimit(ModuleData):
 
 	def actions(self):
 		return [("commandpermission", 100, self.recvCommand)]
+
+	def verifyConfig(self, config):
+		if "ratelimit" in config:
+			if not isinstance(config["ratelimit"], dict):
+				raise ConfigValidationError("ratelimit", "value must be a dictionary")
+			for key, value in config["ratelimit"].itemitems():
+				if key not in ("limit", "kill_limit", "interval"):
+					continue
+				if not isinstance(value, int) or value < 0: # We might want to do some checking for insane values here
+					raise ConfigValidationError("ratelimit", "value \"{}\" is an invalid number".format(key))
 
 	def getConfig(self):
 		config = {

--- a/txircd/modules/extra/sajoin.py
+++ b/txircd/modules/extra/sajoin.py
@@ -1,6 +1,6 @@
 from twisted.plugin import IPlugin
 from twisted.words.protocols import irc
-from txircd.channel import InvalidChannelName, IRCChannel
+from txircd.channel import InvalidChannelNameError, IRCChannel
 from txircd.module_interface import ICommand, IModuleData, Command, ModuleData
 from zope.interface import implements
 
@@ -36,7 +36,7 @@ class SajoinCommand(ModuleData, Command):
 		else:
 			try:
 				channel = IRCChannel(self.ircd, channame)
-			except InvalidChannelName:
+			except InvalidChannelNameError:
 				user.sendSingleError("SajoinCmd", irc.ERR_BADCHANMASK, channame, "Bad channel mask")
 				return None
 		return {

--- a/txircd/modules/extra/sakick.py
+++ b/txircd/modules/extra/sakick.py
@@ -44,6 +44,7 @@ class SakickCommand(ModuleData, Command):
 		reason = user.nick
 		if len(params) > 2:
 			reason = params[2]
+		reason = reason[:self.ircd.config.get("kick_length", 255)]
 		return {
 			"target": target,
 			"channel": channel,

--- a/txircd/modules/extra/sanick.py
+++ b/txircd/modules/extra/sanick.py
@@ -28,7 +28,7 @@ class SanickCommand(ModuleData, Command):
 		if params[0] not in self.ircd.userNicks:
 			user.sendSingleError("SanickCmd", irc.ERR_NOSUCHSERVER, "No such nick/channel")
 			return None
-		if not isValidNick(params[1]):
+		if not isValidNick(params[1]) or len(params[1]) > self.ircd.config.get("nick_length", 32):
 			user.sendSingleError("SanickCmd", irc.ERR_ERRONEUSNICKNAME, params[1], "Erroneous nickname")
 			return None
 		if params[1] in self.ircd.userNicks:

--- a/txircd/modules/extra/satopic.py
+++ b/txircd/modules/extra/satopic.py
@@ -29,7 +29,7 @@ class SatopicCommand(ModuleData, Command):
 			return None
 		return {
 			"channel": self.ircd.channels[params[0]],
-			"topic": params[1][:self.ircd.config.get("topic_length",326)]
+			"topic": params[1][:self.ircd.config.get("topic_length", 326)]
 		}
 
 	def affectedChannels(self, user, data):

--- a/txircd/modules/extra/shun.py
+++ b/txircd/modules/extra/shun.py
@@ -1,5 +1,6 @@
 from twisted.plugin import IPlugin
 from twisted.words.protocols import irc
+from txircd.config import ConfigValidationError
 from txircd.module_interface import Command, ICommand, IModuleData, ModuleData
 from txircd.modules.xlinebase import XLineBase
 from txircd.utils import durationToSeconds, ircLower, now
@@ -28,6 +29,14 @@ class Shun(ModuleData, XLineBase):
 	
 	def load(self):
 		self.initializeLineStorage()
+
+	def verifyConfig(self, config):
+		if "shun_commands" in config:
+			if not isinstance(config["shun_commands"], list):
+				raise ConfigValidationError("shun_commands", "value must be a list")
+			for command in config["shun_commands"]:
+				if not isinstance(command, basestring):
+					raise ConfigValidationError("shun_commands", "\"{}\" is not a valid command".format(command))
 	
 	def checkUserMatch(self, user, mask, data):
 		banMask = self.normalizeMask(mask)

--- a/txircd/modules/rfc/cmd_admin.py
+++ b/txircd/modules/rfc/cmd_admin.py
@@ -1,5 +1,6 @@
 from twisted.plugin import IPlugin
 from twisted.words.protocols import irc
+from txircd.config import ConfigValidationError
 from txircd.module_interface import Command, ICommand, IModuleData, ModuleData
 from zope.interface import implements
 
@@ -23,6 +24,14 @@ class AdminCommand(ModuleData):
 	
 	def serverCommands(self):
 		return [ ("ADMINREQ", 1, ServerAdmin(self.ircd, self.sendAdminData)) ]
+
+	def verifyConfig(self, config):
+		if "admin_server" in config and not isinstance("admin_server", basestring):
+			raise ConfigValidationError("admin_server", "value must be a string")
+		if "admin_admin" in config and not isinstance("admin_admin", basestring):
+			raise ConfigValidationError("admin_admin", "value must be a string")
+		if "admin_email" in config and not isinstance("admin_email", basestring):
+			raise ConfigValidationError("admin_email", "value must be a string")
 	
 	def sendAdminData(self, user, serverName):
 		user.sendMessage(irc.RPL_ADMINME, serverName, "Administrative info for {}".format(serverName))

--- a/txircd/modules/rfc/cmd_away.py
+++ b/txircd/modules/rfc/cmd_away.py
@@ -31,8 +31,10 @@ class AwayCommand(ModuleData, Command):
 	def parseParams(self, user, params, prefix, tags):
 		if not params:
 			return {}
+		message = " ".join(params)
+		message = message[:self.ircd.config.get("away_length", 200)]
 		return {
-			"message": " ".join(params)
+			"message": message
 		}
 	
 	def execute(self, user, data):

--- a/txircd/modules/rfc/cmd_join.py
+++ b/txircd/modules/rfc/cmd_join.py
@@ -1,6 +1,6 @@
 from twisted.plugin import IPlugin
 from twisted.words.protocols import irc
-from txircd.channel import InvalidChannelName, IRCChannel
+from txircd.channel import InvalidChannelNameError, IRCChannel
 from txircd.module_interface import Command, ICommand, IModuleData, ModuleData
 from zope.interface import implements
 
@@ -77,7 +77,7 @@ class JoinChannel(Command):
 		for chan in joiningChannels:
 			try:
 				channels.append(self.ircd.channels[chan] if chan in self.ircd.channels else IRCChannel(self.ircd, chan))
-			except InvalidChannelName:
+			except InvalidChannelNameError:
 				user.sendBatchedError("JoinCmd", irc.ERR_BADCHANMASK, chanName, "Bad channel mask")
 		return {
 			"channels": channels,

--- a/txircd/modules/rfc/cmd_kick.py
+++ b/txircd/modules/rfc/cmd_kick.py
@@ -111,6 +111,7 @@ class UserKick(Command):
 		reason = user.nick
 		if len(params) > 2:
 			reason = params[2]
+		reason = reason[:self.ircd.config.get("kick_length", 255)]
 		return {
 			"channel": channel,
 			"user": targetUser,

--- a/txircd/modules/rfc/cmd_mode.py
+++ b/txircd/modules/rfc/cmd_mode.py
@@ -17,7 +17,8 @@ class ModeCommand(ModuleData):
 				("modechanges-channel", 1, self.sendChannelModesToServers),
 				("modemessage-user", 1, self.sendUserModesToUsers),
 				("modechanges-user", 1, self.sendUserModesToServers),
-				("commandpermission-MODE", 1, self.restrictUse) ]
+				("commandpermission-MODE", 1, self.restrictUse),
+				("buildisupport", 1, self.buildISupport) ]
 	
 	def userCommands(self):
 		return [ ("MODE", 1, UserMode(self.ircd)) ]
@@ -121,6 +122,9 @@ class ModeCommand(ModuleData):
 			user.sendMessage(irc.ERR_CHANOPRIVSNEEDED, channel.name, "You do not have access to set channel modes")
 			return False
 		return None
+
+	def buildISupport(self, data):
+		data["MODES"] = self.ircd.config.get("modes_per_line", 20)
 
 class UserMode(Command):
 	implements(ICommand)

--- a/txircd/modules/rfc/cmd_nick.py
+++ b/txircd/modules/rfc/cmd_nick.py
@@ -45,7 +45,7 @@ class NickUserCommand(Command):
 		if not params or not params[0]:
 			user.sendSingleError("NickCmd", irc.ERR_NEEDMOREPARAMS, "NICK", "Not enough parameters")
 			return None
-		if not isValidNick(params[0]):
+		if not isValidNick(params[0]) or len(params[0]) > self.ircd.config.get("nick_length", 32):
 			user.sendSingleError("NickCmd", irc.ERR_ERRONEUSNICKNAME, params[0], "Erroneous nickname")
 			return None
 		if params[0] in self.ircd.userNicks:

--- a/txircd/modules/rfc/cmd_nick.py
+++ b/txircd/modules/rfc/cmd_nick.py
@@ -1,5 +1,6 @@
 from twisted.plugin import IPlugin
 from twisted.words.protocols import irc
+from txircd.config import ConfigValidationError
 from txircd.module_interface import Command, ICommand, IModuleData, ModuleData
 from txircd.utils import isValidNick, timestamp
 from zope.interface import implements
@@ -14,13 +15,22 @@ class NickCommand(ModuleData):
 	def actions(self):
 		return [ ("changenickmessage", 1, self.sendNickMessage),
 				("changenick", 1, self.broadcastNickChange),
-				("remotechangenick", 1, self.broadcastNickChange) ]
+				("remotechangenick", 1, self.broadcastNickChange),
+		        ("buildisupport", 1, self.buildISupport) ]
 	
 	def userCommands(self):
 		return [ ("NICK", 1, NickUserCommand(self.ircd)) ]
 	
 	def serverCommands(self):
 		return [ ("NICK", 1, NickServerCommand(self.ircd)) ]
+
+	def verifyConfig(self, config):
+		if "nick_length" in config:
+			if not isinstance(config["nick_length"], int) or config["nick_length"] < 0:
+				raise ConfigValidationError("nick_length", "invalid number")
+			elif config["nick_length"] > 32:
+				config["nick_length"] = 32
+				self.ircd.logConfigValidationWarning("nick_length", "value is too large", 32)
 	
 	def sendNickMessage(self, userShowList, user, oldNick):
 		def transformUser(sayingUser):
@@ -32,6 +42,9 @@ class NickCommand(ModuleData):
 	def broadcastNickChange(self, user, oldNick, fromServer):
 		nickTS = str(timestamp(user.nickSince))
 		self.ircd.broadcastToServers(fromServer, "NICK", nickTS, user.nick, prefix=user.uuid)
+
+	def buildISupport(self, data):
+		data["NICKLEN"] = self.ircd.config.get("nick_length", 32)
 
 class NickUserCommand(Command):
 	implements(ICommand)

--- a/txircd/modules/rfc/cmd_pass.py
+++ b/txircd/modules/rfc/cmd_pass.py
@@ -1,5 +1,6 @@
 from twisted.plugin import IPlugin
 from twisted.words.protocols import irc
+from txircd.config import ConfigValidationError
 from txircd.module_interface import Command, ICommand, IModuleData, ModuleData
 from zope.interface import implements
 
@@ -15,6 +16,10 @@ class PassCommand(ModuleData, Command):
 	
 	def userCommands(self):
 		return [ ("PASS", 1, self) ]
+
+	def verifyConfig(self, config):
+		if "server_password" in config and not isinstance(config["server_password"], basestring):
+			raise ConfigValidationError("server_password", "value must be a string")
 	
 	def parseParams(self, user, params, prefix, tags):
 		if not params:

--- a/txircd/modules/rfc/cmd_rehash.py
+++ b/txircd/modules/rfc/cmd_rehash.py
@@ -1,6 +1,6 @@
 from twisted.plugin import IPlugin
 from twisted.words.protocols import irc
-from txircd.config import ConfigReadError
+from txircd.config import ConfigError
 from txircd.module_interface import Command, ICommand, IModuleData, ModuleData
 from zope.interface import implements
 from fnmatch import fnmatchcase
@@ -70,7 +70,7 @@ class UserRehash(Command):
 		user.sendMessage(irc.RPL_REHASHING, self.ircd.config.fileName, "Rehashing")
 		try:
 			self.ircd.rehash()
-		except ConfigReadError as e:
+		except ConfigError as e:
 			user.sendMessage(irc.RPL_REHASHING, self.ircd.config.fileName, "Rehash failed: {}".format(e))
 
 class ServerRehash(Command):
@@ -104,7 +104,7 @@ class ServerRehash(Command):
 			user = None
 		try:
 			self.ircd.rehash()
-		except ConfigReadError as e:
+		except ConfigError as e:
 			if user:
 				user.sendMessage(irc.RPL_REHASHING, self.ircd.config.fileName, "Rehash failed: {}".format(e))
 		return True

--- a/txircd/modules/rfc/cmd_stats.py
+++ b/txircd/modules/rfc/cmd_stats.py
@@ -1,5 +1,6 @@
 from twisted.plugin import IPlugin
 from twisted.words.protocols import irc
+from txircd.config import ConfigValidationError
 from txircd.module_interface import Command, ICommand, IModuleData, ModuleData
 from zope.interface import implements
 
@@ -21,6 +22,14 @@ class StatsCommand(ModuleData, Command):
 		return [ ("INFOREQ", 1, ServerInfoRequest(self.ircd)),
 				("INFO", 1, ServerInfo(self.ircd)),
 				("INFOEND", 1, ServerInfoEnd(self.ircd)) ]
+
+	def verifyConfig(self, config):
+		if "public_info" in config:
+			if not isinstance(config["public_info"], list):
+				raise ConfigValidationError("public_info", "value must be a list")
+			for info in config["public_info"]:
+				if not isinstance(info, basestring):
+					raise ConfigValidationError("public_info", "every entry must be a string")
 
 class UserStats(Command):
 	implements(ICommand)

--- a/txircd/modules/rfc/cmd_topic.py
+++ b/txircd/modules/rfc/cmd_topic.py
@@ -64,7 +64,7 @@ class UserTopic(Command):
 			return {
 				"channel": channel
 			}
-		topic = params[1][:self.ircd.config.get("topic_length",326)]
+		topic = params[1][:self.ircd.config.get("topic_length", 326)]
 		return {
 			"channel": channel,
 			"topic": topic

--- a/txircd/modules/rfc/cmd_topic.py
+++ b/txircd/modules/rfc/cmd_topic.py
@@ -1,5 +1,6 @@
 from twisted.plugin import IPlugin
 from twisted.words.protocols import irc
+from txircd.config import ConfigValidationError
 from txircd.module_interface import Command, ICommand, IModuleData, ModuleData
 from txircd.utils import timestamp
 from zope.interface import implements
@@ -15,13 +16,22 @@ class TopicCommand(ModuleData):
 	
 	def actions(self):
 		return [ ("topic", 1, self.onTopic),
-				("join", 2, self.sendChannelTopic) ]
+				("join", 2, self.sendChannelTopic),
+				("buildisupport", 1, self.buildISupport) ]
 	
 	def userCommands(self):
 		return [ ("TOPIC", 1, UserTopic(self.ircd, self)) ]
 	
 	def serverCommands(self):
 		return [ ("TOPIC", 1, ServerTopic(self.ircd)) ]
+
+	def verifyConfig(self, config):
+		if "topic_length" in config:
+			if not isinstance(config["topic_length"], int) or config["topic_length"] < 0:
+				raise ConfigValidationError("topic_length", "invalid number")
+			elif config["topic_length"] > 326:
+				config["topic_length"] = 326
+				self.ircd.logConfigValidationWarning("topic_length", "value is too large", 326)
 	
 	def onTopic(self, channel, setter, oldTopic):
 		for user in channel.users.iterkeys():
@@ -44,6 +54,9 @@ class TopicCommand(ModuleData):
 		else:
 			user.sendMessage(irc.RPL_TOPIC, channel.name, channel.topic)
 			user.sendMessage(irc.RPL_TOPICWHOTIME, channel.name, channel.topicSetter, str(timestamp(channel.topicTime)))
+
+	def buildISupport(self, data):
+		data["TOPICLEN"] = self.ircd.config.get("topic_length", 326)
 
 class UserTopic(Command):
 	implements(ICommand)

--- a/txircd/modules/rfc/cmd_user.py
+++ b/txircd/modules/rfc/cmd_user.py
@@ -20,7 +20,8 @@ class UserCommand(Command, ModuleData):
 		if not params[3]: # Make sure the gecos isn't an empty string
 			user.sendSingleError("UserCmd", irc.ERR_NEEDMOREPARAMS, "USER", "Not enough parameters")
 			return None
-		params[0] = params[0][:12] # Trim down to 12 characters to guarantee it won't be rejected by the user class for being too long
+		# Trim down to a default of 12 characters to guarantee it won't be rejected by the user class for being too long
+		params[0] = params[0][:self.ircd.config.get("ident_length", 12)]
 		for char in params[0]: # Validate the ident
 			if not char.isalnum() and char not in "-.[\]^_`{|}":
 				user.sendSingleError("UserCmd", irc.ERR_NEEDMOREPARAMS, "USER", "Your username is not valid") # The RFC is dumb.

--- a/txircd/modules/rfc/cmd_user.py
+++ b/txircd/modules/rfc/cmd_user.py
@@ -20,8 +20,9 @@ class UserCommand(Command, ModuleData):
 		if not params[3]: # Make sure the gecos isn't an empty string
 			user.sendSingleError("UserCmd", irc.ERR_NEEDMOREPARAMS, "USER", "Not enough parameters")
 			return None
-		# Trim down to a default of 12 characters to guarantee it won't be rejected by the user class for being too long
+		# Trim down to guarantee ident and gecos won't be rejected by the user class for being too long
 		params[0] = params[0][:self.ircd.config.get("ident_length", 12)]
+		params[3] = params[3][:self.ircd.config.get("gecos_length", 128)]
 		for char in params[0]: # Validate the ident
 			if not char.isalnum() and char not in "-.[\]^_`{|}":
 				user.sendSingleError("UserCmd", irc.ERR_NEEDMOREPARAMS, "USER", "Your username is not valid") # The RFC is dumb.

--- a/txircd/modules/rfc/cmd_whowas.py
+++ b/txircd/modules/rfc/cmd_whowas.py
@@ -1,5 +1,6 @@
 from twisted.plugin import IPlugin
 from twisted.words.protocols import irc
+from txircd.config import ConfigValidationError
 from txircd.module_interface import Command, ICommand, IModuleData, ModuleData
 from txircd.utils import durationToSeconds, ircLower, now, timestamp
 from zope.interface import implements
@@ -22,6 +23,12 @@ class WhowasCommand(ModuleData, Command):
 	def load(self):
 		if "whowas" not in self.ircd.storage:
 			self.ircd.storage["whowas"] = {}
+
+	def verifyConfig(self, config):
+		if "whowas_duration" in config and not isinstance(config["whowas_duration"], basestring) and not isinstance(config["whowas_duration"], int):
+			raise ConfigValidationError("whowas_duration", "value must be an integer or a duration string")
+		if "whowas_max_entries" in config and (not isinstance(config["whowas_max_entries"], int) or config["whowas_max_entries"] < 0):
+			raise  ConfigValidationError("whowas_max_entries", "invalid number")
 	
 	def removeOldEntries(self, whowasEntries):
 		expireDuration = durationToSeconds(self.ircd.config.get("whowas_duration", "1d"))

--- a/txircd/modules/server/autoconnect.py
+++ b/txircd/modules/server/autoconnect.py
@@ -1,5 +1,6 @@
 from twisted.internet.task import LoopingCall
 from twisted.plugin import IPlugin
+from txircd.config import ConfigValidationError
 from txircd.module_interface import IModuleData, ModuleData
 from txircd.utils import durationToSeconds
 from zope.interface import implements
@@ -23,7 +24,17 @@ class ServerAutoconnect(ModuleData):
 		if self.connector.running:
 			self.connector.stop()
 		self.connector.start(durationToSeconds(self.ircd.config.get("autoconnect_period", 60)), False)
-	
+
+	def verifyConfig(self, config):
+		if "autoconnect_period" in config and (not isinstance(config["autoconnect_period"], int) or config["autoconnect_period"] < 0):
+			raise ConfigValidationError("autoconnect_period", "invalid number")
+		if "autoconnect" in config:
+			if not isinstance(config["autoconnect"], list):
+				raise ConfigValidationError("autoconnect", "value must be a list")
+			for server in config["autoconnect"]:
+				if not isinstance(server, basestring):
+					raise ConfigValidationError("autoconnect", "every entry must be a string")
+
 	def runConnections(self):
 		autoconnectServers = self.ircd.config.get("autoconnect", [])
 		for serverName in autoconnectServers:

--- a/txircd/user.py
+++ b/txircd/user.py
@@ -377,6 +377,8 @@ class IRCUser(IRCBase):
 		Changes a user's real name. If initiated by a remote server, that
 		server should be specified in the fromServer parameter.
 		"""
+		if len(newGecos) > self.ircd.config.get("gecos_length", 128):
+			return
 		if newGecos == self.gecos:
 			return
 		oldGecos = self.gecos

--- a/txircd/user.py
+++ b/txircd/user.py
@@ -21,7 +21,7 @@ class IRCUser(IRCBase):
 				resolvedHost = gethostbyaddr(ip)[0]
 				# First half of host resolution done, run second half to prevent rDNS spoofing.
 				# Refuse hosts that are too long as well.
-				if ip == gethostbyname(resolvedHost) and len(resolvedHost) <= 64 and isValidHost(resolvedHost):
+				if ip == gethostbyname(resolvedHost) and len(resolvedHost) <= self.ircd.config.get("hostname_length", 64) and isValidHost(resolvedHost):
 					host = resolvedHost
 				else:
 					host = ip
@@ -345,7 +345,7 @@ class IRCUser(IRCBase):
 		"""
 		if newIdent == self.ident:
 			return
-		if len(newIdent) > 12:
+		if len(newIdent) > self.ircd.config.get("ident_length", 12):
 			return
 		oldIdent = self.ident
 		self.ident = newIdent
@@ -357,7 +357,7 @@ class IRCUser(IRCBase):
 		Changes a user's host. If initiated by a remote server, that server
 		should be specified in the fromServer parameter.
 		"""
-		if len(newHost) > 64:
+		if len(newHost) > self.ircd.config.get("hostname_length", 64):
 			return
 		if newHost == self.host:
 			return
@@ -572,7 +572,7 @@ class IRCUser(IRCBase):
 		setBy = self._sourceName(user.uuid)
 		setTime = now()
 		for mode in modes:
-			if len(changes) >= 20:
+			if len(changes) >= self.ircd.config.get("modes_per_line", 20):
 				break
 			if mode == "+":
 				adding = True
@@ -600,7 +600,7 @@ class IRCUser(IRCBase):
 				continue
 			
 			for parameter in paramList:
-				if len(changes) >= 20:
+				if len(changes) >= self.ircd.config.get("modes_per_line", 20):
 					break
 				if not override and self.ircd.runActionUntilValue("modepermission-user-{}".format(mode), self, user, adding, parameter, users=[self, user]) is False:
 					continue
@@ -799,7 +799,7 @@ class RemoteUser(IRCUser):
 		Changes the ident of the user. If the change was initiated by a remote
 		server, that server should be specified as the fromServer parameter.
 		"""
-		if len(newIdent) > 12:
+		if len(newIdent) > self.ircd.config.get("ident_length", 12):
 			return
 		oldIdent = self.ident
 		self.ident = newIdent
@@ -812,7 +812,7 @@ class RemoteUser(IRCUser):
 		remote server, that server should be specified as the fromServer
 		parameter.
 		"""
-		if len(newHost) > 64:
+		if len(newHost) > self.ircd.config.get("hostname_length", 64):
 			return
 		oldHost = self.host
 		self.host = newHost

--- a/txircd/user.py
+++ b/txircd/user.py
@@ -608,7 +608,7 @@ class IRCUser(IRCBase):
 					continue
 				if adding:
 					if modeType == ModeType.List:
-						if mode in self.modes and len(self.modes[mode]) > self.ircd.config.get("user_list_limit", 128):
+						if mode in self.modes and len(self.modes[mode]) > self.ircd.config.get("user_listmode_limit", 128):
 							user.sendMessage(irc.ERR_BANLISTFULL, self.name, parameter, "Channel +{} list is full".format(mode))
 							continue
 				if self._applyMode(adding, modeType, mode, parameter, setBy, setTime):
@@ -626,7 +626,7 @@ class IRCUser(IRCBase):
 		if adding:
 			if modeType == ModeType.List:
 				if mode in self.modes:
-					if len(self.modes[mode]) > self.ircd.config.get("user_list_limit", 128):
+					if len(self.modes[mode]) > self.ircd.config.get("user_listmode_limit", 128):
 						return False
 					for paramData in self.modes[mode]:
 						if parameter == paramData[0]:

--- a/txircd/utils.py
+++ b/txircd/utils.py
@@ -2,7 +2,7 @@ from collections import MutableMapping
 from datetime import datetime
 import re
 
-validNick = re.compile(r"^[a-zA-Z\-\[\]\\`^{}_|][a-zA-Z0-9\-\[\]\\1^{}_|]{0,31}$")
+validNick = re.compile(r"^[a-zA-Z\-\[\]\\`^{}_|][a-zA-Z0-9\-\[\]\\1^{}_|]+$")
 def isValidNick(nick):
 	"""
 	Determines whether the provided nickname is in a valid format.


### PR DESCRIPTION
Since we're still in the breakage phase of txircd 0.4, I give you a breaking, yet valuable in my opinion, change.

So let's go over the things that are in this PR:
- Replacement of a lot of magic numbers with configurable equivalents. I kinda took this upon myself because the amount of magic numbers we have bothered me. Making these configurable is, in my opinion, a change that will not only make the codebase cleaner and assure that these numbers are always the same in all cases (see my fix in TOPICLEN for an example on this one), but also make txircd a lot more configurable for our users. One could argue that a lot of these numbers should never be changed, but I prefer going the InspIRCd route of "configurable but discouraged" over "not configurable at all". Besides, we already had some of them configurable. It doesn't really make sense to make some configurable and some hardcoded.

- The addition of a few new limits. We did not yet have limits on our gecos, our AWAY messages and our KICK reasons. In my opinion they should be present since I was working on the limits anyway, I added them. The default values were taken from InspIRCd.

- Modularization of extra ISUPPORT tokens. The last change is for the ISUPPORT dictionary generation, which now allows modules to add their own tokens on top of the default ones we already have. In theory we could even move the tokens that belong to core modules to their respective modules, but I'll let you be the judge on that one.