### PR TITLE
Always cloak the user's real host

### DIFF
--- a/txircd/modules/extra/cloaking.py
+++ b/txircd/modules/extra/cloaking.py
@@ -38,13 +38,13 @@ class HostCloaking(ModuleData, Mode):
 
 	def apply(self, actionType, user, param, settingUser, uid, adding, *params, **kw):
 		if adding:
-			userHost = user.host
+			userHost = user.realHost
 			if isIPv6Address(userHost):
 				user.changeHost(self.applyIPv6Cloak(userHost))
 			elif isIPAddress(userHost):
 				user.changeHost(self.applyIPv4Cloak(userHost))
 			else:
-				if "." in user.host:
+				if "." in userHost:
 					user.changeHost(self.applyHostCloak(userHost, user.ip))
 				else:
 					if isIPv6Address(user.ip):


### PR DESCRIPTION
Not sure what I was thinking when I wrote the initial implementation of this, but we should always be cloaking the real host of the user rather than assuming that the host they have at the time of applying the cloak is their actual real host.