### PR TITLE
Remove an extra colon

### DIFF
--- a/txircd/modules/ircv3/cap.py
+++ b/txircd/modules/ircv3/cap.py
@@ -102,7 +102,7 @@ class Cap(ModuleData, Command):
 			return {
 				"subcmd": "END"
 			}
-		user.sendSingleError("CapSubcmd", irc.ERR_INVALIDCAPCMD, subcmd, ":Invalid subcommand")
+		user.sendSingleError("CapSubcmd", irc.ERR_INVALIDCAPCMD, subcmd, "Invalid subcommand")
 		return None
 	
 	def execute(self, user, data):


### PR DESCRIPTION
Since we already add the colons when we send the message, this resulted in two colons being sent.