### PR TITLE
Include the network name in RPL_WELCOME

### DIFF
--- a/txircd/user.py
+++ b/txircd/user.py
@@ -295,7 +295,7 @@ class IRCUser(IRCBase):
 				return
 			self.ircd.log.debug("Registering user {user.uuid} ({user.hostmask()})", user=self)
 			versionWithName = "txircd-{}".format(version)
-			self.sendMessage(irc.RPL_WELCOME, "Welcome to the Internet Relay Chat Network {}".format(self.hostmask()))
+			self.sendMessage(irc.RPL_WELCOME, "Welcome to the {} Internet Relay Chat Network {}".format(self.ircd.config["network_name"], self.hostmask()))
 			self.sendMessage(irc.RPL_YOURHOST, "Your host is {}, running version {}".format(self.ircd.name, versionWithName))
 			self.sendMessage(irc.RPL_CREATED, "This server was created {}".format(self.ircd.startupTime.replace(microsecond=0)))
 			chanModes = "".join(["".join(modes.keys()) for modes in self.ircd.channelModes])


### PR DESCRIPTION
While this is not part of the RFC, pretty much every well-known IRCd does this. As such we're adding a bit of consistency with other implementations. A lot of modern IRCds also abbreviate the "Internet Relay Chat" to just "IRC", but I don't know if that's really necessary.