### PR TITLE
Send 442 when trying to PART a channel you're not on

### DIFF
--- a/txircd/modules/rfc/cmd_part.py
+++ b/txircd/modules/rfc/cmd_part.py
@@ -70,6 +70,7 @@ class UserPart(Command):
 			return None
 		channel = self.ircd.channels[params[0]]
 		if user not in channel.users:
+			user.sendSingleError("PartCmd", irc.ERR_NOTONCHANNEL, params[0], "You're not on that channel")
 			return None
 		reason = params[1] if len(params) > 1 else ""
 		reason = reason[:self.ircd.config.get("part_message_length", 300)]


### PR DESCRIPTION
This just failed silently, which probably shouldn't happen. This numeric is also mentioned in RFC1459 and used in this way by at least 2 other big IRCds. We also did this in 0.2, but it seems to have gotten lost in the rewrite.