### PR TITLE
Make the INSTALL instructions nice to read again

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,12 +1,15 @@
+Installation instructions
+=========================
+
 The following steps can be done either directly to the system or in a virtualenv.
 
-Install dependencies:
-    pip install -r requirements.txt
+1. Install dependencies:  
+`pip install -r requirements.txt`
 
-Create a config file in the current directory:
-    edit txircd.yaml
+2. Copy `txircd-example.yaml` to `txircd.yaml`, and edit the configuration. Do the same for included files in the `conf/` directory.
 
-Run txircd in the foreground:
-    twistd -n txircd
-or allow it to daemonise:
-    twistd txircd
+3. Allow txircd to deamonize:  
+`twistd txircd`  
+or run it in the foreground:  
+`twistd -n txircd`  
+(If you're running in a virtualenv, start txircd with the twistd in your virtualenv.)


### PR DESCRIPTION
The conversion to markdown squished all the commands into the same line as their instruction, which not only looks really ugly, but also makes it annoying to read.

Before:
![capture](https://cloud.githubusercontent.com/assets/1357231/12400977/9bbeb7f2-be23-11e5-9452-f9d3dd759fd3.PNG)

After:
![capture2](https://cloud.githubusercontent.com/assets/1357231/12400982/a14ef4e8-be23-11e5-95fa-3f4832bc4fdb.PNG)