### PR TITLE
Fix the missing prefix in the KICK message

### DIFF
--- a/txircd/modules/rfc/cmd_kick.py
+++ b/txircd/modules/rfc/cmd_kick.py
@@ -85,12 +85,12 @@ class KickCommand(ModuleData):
 			if "user" not in typeData:
 				return
 			sourceUser = typeData["user"]
-			kwArgs["sourceuser"] = sourceUser
+			kwArgs["prefix"] = sourceUser.hostmask()
 		else:
 			if "server" not in typeData:
 				return
 			sourceServer = typeData["server"]
-			kwArgs["sourceserver"] = sourceServer
+			kwArgs["prefix"] = sourceServer.name
 		
 		reason = sourceUser.nick if byUser else sourceServer.name
 		if "reason" in typeData:


### PR DESCRIPTION
The KICK message currently does not have a prefix, so it gets assigned the default server prefix instead of the user/server that was actually the kicker.