### PR TITLE
Add STATS types for online opers, ports and server uptime

### DIFF
--- a/conf/extra-modules-example.yaml
+++ b/conf/extra-modules-example.yaml
@@ -148,6 +148,18 @@ modules:
 # notifies opers of user disconnections on remote servers.
 #- ServerNoticeRemoteQuit
 
+# StatsOnlineOpers: Provides the onlineopers STATS type, which lists all opers
+# that are currently online.
+#- StatsOnlineOpers
+
+# StatsPorts: Provides the ports STATS type, which lists all client and server
+# ports the server is currently listening on.
+#- StatsPorts
+
+# StatsUptime: Provides the uptime STATS type, which shows how long the server
+# has been running for.
+#- StatsUptime
+
 # StripColors: Provides a channel mode (+S) that strips formatting from
 # messages sent to the channel.
 #- StripColors

--- a/docs/oper-permissions.md
+++ b/docs/oper-permissions.md
@@ -25,11 +25,11 @@ command-squit         | Allows the use of the SQUIT command to disconnect a serv
 command-unloadmodule  | Allows the use of the UNLOADMODULE command to unload a module on the server. Note that core modules cannot be unloaded.
 command-wallops       | Allows the use of the WALLOPS command to send a WALLOPS message.
 command-zline         | Allows the use of the ZLINE command to globally ban an IP address.
-info-elines           | Allows an oper to view the ELINES STATS type.
-info-klines           | Allows an oper to view the KLINES STATS type.
-info-glines           | Allows an oper to view the GLINES STATS type.
-info-qlines           | Allows an oper to view the QLINES STATS type.
-info-zlines           | Allows an oper to view the ZLINES STATS type.
+info-elines           | Allows an oper to view the elines STATS type.
+info-klines           | Allows an oper to view the klines STATS type.
+info-glines           | Allows an oper to view the glines STATS type.
+info-qlines           | Allows an oper to view the qlines STATS type.
+info-zlines           | Allows an oper to view the zlines STATS type.
 whois-host            | Allows an oper to see the real host and IP address of any user.
 
 
@@ -51,7 +51,10 @@ command-sanick            | SanickCommand             | Allows the use of the SA
 command-sapart            | SapartCommand             | Allows the use of the SAPART command to force part a user from a channel.
 command-satopic           | SatopicCommand            | Allows the use of the SATOPIC command to force change the topic of any channel.
 command-shun              | ShunCommand               | Allows the use of the SHUN command to ban a user from sending most commands.
-info-shuns                | ShunCommand               | Allows an oper to view the SHUNS STATS type.
+info-onlineopers          | StatsOnlineOpers          | Allows an oper to view the onlineopers STATS type.
+info-ports                | StatsPorts                | Allows an oper to view the ports STATS type.
+info-shuns                | ShunCommand               | Allows an oper to view the shuns STATS type.
+info-uptime               | StatsOnlineUptime         | Allows an oper to view the uptime STATS type.
 view-globops              | Globops                   | Allows an oper to see GLOBOPS messages.
 servernotice-connect      | ServerNoticeConnect       | Allows an oper to set usermode +s on themselves and grants permission for local connect notices.
 servernotice-oper         | ServerNoticeOper          | Allows an oper to set usermode +s on themselves and grants permission for oper notices.

--- a/txircd-example.yaml
+++ b/txircd-example.yaml
@@ -177,8 +177,12 @@
 # This controls which STATS options are available to everyone rather than just
 # opers. Options not listed here will be available only to opers.
 # Specify this as a list of options. If not specified, the default is no
-# options.
-#public_info: []
+# options. The example shown below requires the StatsOnlineOpers and
+# StatsUptime modules to be loaded; see the extra modules include at the bottom
+# of this file for more.
+#public_info:
+#- onlineopers
+#- uptime
 
 # log_level
 # This determines the level at which we log information to the log file after

--- a/txircd/modules/extra/stats_onlineopers.py
+++ b/txircd/modules/extra/stats_onlineopers.py
@@ -1,0 +1,21 @@
+from twisted.plugin import IPlugin
+from txircd.module_interface import IModuleData, ModuleData
+from txircd.utils import now
+from zope.interface import implements
+
+class StatsOnlineOpers(ModuleData):
+	implements(IPlugin, IModuleData)
+
+	name = "StatsOnlineOpers"
+
+	def actions(self):
+		return [ ("statsruntype-onlineopers", 10, self.listOnlineOpers) ]
+
+	def listOnlineOpers(self):
+		info = {}
+		for user in self.ircd.users.itervalues():
+			if self.ircd.runActionUntilValue("userhasoperpermission", user, "", users=[user]):
+				info[user.nick] = "{} ({}@{}) Idle: {} secs".format(user.nick, user.ident, user.host(), int((now() - user.idleSince).total_seconds()))
+		return info
+
+statsOnlineOpers = StatsOnlineOpers()

--- a/txircd/modules/extra/stats_ports.py
+++ b/txircd/modules/extra/stats_ports.py
@@ -1,0 +1,23 @@
+from twisted.plugin import IPlugin
+from txircd.factory import UserFactory
+from txircd.module_interface import IModuleData, ModuleData
+from zope.interface import implements
+
+class StatsPorts(ModuleData):
+	implements(IPlugin, IModuleData)
+
+	name = "StatsPorts"
+
+	def actions(self):
+		return [ ("statsruntype-ports", 10, self.listPorts) ]
+
+	def listPorts(self):
+		info = {}
+		for portDesc, portData in self.ircd.boundPorts.iteritems():
+			if isinstance(portData.factory, UserFactory):
+				info[str(portData.port)] = "{} (clients)".format(portDesc)
+			else:
+				info[str(portData.port)] = "{} (servers)".format(portDesc)
+		return info
+
+statsPorts = StatsPorts()

--- a/txircd/modules/extra/stats_uptime.py
+++ b/txircd/modules/extra/stats_uptime.py
@@ -1,0 +1,20 @@
+from twisted.plugin import IPlugin
+from txircd.module_interface import IModuleData, ModuleData
+from txircd.utils import now
+from zope.interface import implements
+
+class StatsUptime(ModuleData):
+	implements(IPlugin, IModuleData)
+
+	name = "StatsUptime"
+
+	def actions(self):
+		return [ ("statsruntype-uptime", 10, self.displayUptime) ]
+
+	def displayUptime(self):
+		uptime = now() - self.ircd.startupTime
+		return {
+			self.ircd.name: "Server up {}".format(uptime if uptime.days > 0 else "0 days, {}".format(uptime))
+		}
+
+statsUptime = StatsUptime()


### PR DESCRIPTION
Pretty much what it says on the tin. I also added onlineopers and uptime to the public_info node in the example config. I think that was one of the things that came up when we initially wrote the config for 0.3.