### PR TITLE
Fix an old module name in the permissions doc

### DIFF
--- a/docs/oper-permissions.md
+++ b/docs/oper-permissions.md
@@ -51,10 +51,10 @@ command-samode            | SamodeCommand             | Allows the use of the SA
 command-sanick            | SanickCommand             | Allows the use of the SANICK command to change the nickname of any user.
 command-sapart            | SapartCommand             | Allows the use of the SAPART command to force part a user from a channel.
 command-satopic           | SatopicCommand            | Allows the use of the SATOPIC command to force change the topic of any channel.
-command-shun              | ShunCommand               | Allows the use of the SHUN command to ban a user from sending most commands.
+command-shun              | Shun                      | Allows the use of the SHUN command to ban a user from sending most commands.
 info-onlineopers          | StatsOnlineOpers          | Allows an oper to view the onlineopers STATS type.
 info-ports                | StatsPorts                | Allows an oper to view the ports STATS type.
-info-shuns                | ShunCommand               | Allows an oper to view the shuns STATS type.
+info-shuns                | Shun                      | Allows an oper to view the shuns STATS type.
 info-uptime               | StatsUptime               | Allows an oper to view the uptime STATS type.
 servernotice-connect      | ServerNoticeConnect       | Allows an oper to set usermode +s on themselves and grants permission for local connect notices.
 servernotice-oper         | ServerNoticeOper          | Allows an oper to set usermode +s on themselves and grants permission for oper notices.


### PR DESCRIPTION
'ShunCommand' was rewritten for 0.4 as simply 'Shun'.