### PR TITLE
Store real host and IP in WHOWAS information

### DIFF
--- a/docs/oper-permissions.md
+++ b/docs/oper-permissions.md
@@ -32,6 +32,7 @@ info-qlines           | Allows an oper to view the qlines STATS type.
 info-zlines           | Allows an oper to view the zlines STATS type.
 override-invisible    | Allows an oper to view users in /NAMES, /WHO, and other lists even if they wouldn't be able to due to the user mode +i being set.
 whois-host            | Allows an oper to see the real host and IP address of any user.
+whowas-host           | Allows an oper to see the real host and IP address in any user's WHOWAS information.
 
 
 Extra Permissions

--- a/setup-utils/data_upgrade_from_0.4.py
+++ b/setup-utils/data_upgrade_from_0.4.py
@@ -14,13 +14,15 @@ except Exception as err:
 	print("Error opening data file: {}".format(err))
 	sys.exit(1)
 
-# SECTION: Upgrade whowas time format
+# SECTION: Upgrade whowas time format and add real host and IP keys
 from datetime import datetime
 whowasEntries = storage["whowas"]
 for whowasEntryList in whowasEntries.itervalues():
 	for whowasEntry in whowasEntryList:
 		when = whowasEntry["when"]
 		whowasEntry["when"] = datetime.utcfromtimestamp(when)
+		whowasEntry["realhost"] = whowasEntry["host"]
+		whowasEntry["ip"] = "0.0.0.0"
 
 # SHUTDOWN: Close data.db
 storage.close()

--- a/txircd/modules/rfc/cmd_whowas.py
+++ b/txircd/modules/rfc/cmd_whowas.py
@@ -6,6 +6,8 @@ from txircd.utils import durationToSeconds, ircLower, now
 from zope.interface import implements
 from datetime import datetime, timedelta
 
+irc.RPL_WHOWASIP = "379"
+
 class WhowasCommand(ModuleData, Command):
 	implements(IPlugin, IModuleData, ICommand)
 	
@@ -58,6 +60,8 @@ class WhowasCommand(ModuleData, Command):
 			"nick": user.nick,
 			"ident": user.ident,
 			"host": user.host(),
+			"realhost": user.realHost,
+			"ip": user.ip,
 			"gecos": user.gecos,
 			"server": serverName,
 			"when": now()
@@ -96,6 +100,8 @@ class WhowasCommand(ModuleData, Command):
 		for entry in whowasEntries:
 			entryNick = entry["nick"]
 			user.sendMessage(irc.RPL_WHOWASUSER, entryNick, entry["ident"], entry["host"], "*", entry["gecos"])
+			if self.ircd.runActionUntilValue("userhasoperpermission", user, "whowas-host", users=[user]):
+				user.sendMessage(irc.RPL_WHOWASIP, entryNick, "was connecting from {}@{} {}".format(entry["ident"], entry["realhost"], entry["ip"]))
 			user.sendMessage(irc.RPL_WHOISSERVER, entryNick, entry["server"], str(datetime.utcfromtimestamp(entry["when"])))
 		user.sendMessage(irc.RPL_ENDOFWHOWAS, nick, "End of WHOWAS")
 		return True


### PR DESCRIPTION
When trying to ban or look up information about a user that jumps IPs a lot and with the cloaking module automatically applied, this can be very useful. Otherwise you only have the cloaked host and that's useless when trying to set an x:line. 

This goes without saying, but this information is only available to opers, through the `whowas-host` permission.

The numeric is custom and taken from InspIRCd.

The only issue I can see with this is we might need a conversion tool from txircd 0.4 to txircd 0.5 to make sure the existing database won't freak out over not having these new dictionary keys.