### PR TITLE
Remove some unused fields

### DIFF
--- a/txircd/modules/extra/cloaking.py
+++ b/txircd/modules/extra/cloaking.py
@@ -11,8 +11,6 @@ class HostCloaking(ModuleData, Mode):
 
 	name = "HostCloaking"
 	affectedActions = { "modechange-user-x": 10 }
-	cloakingSalt = None
-	cloakingPrefix = None
 
 	def userModes(self):
 		return [ ("x", ModeType.NoParam, self) ]


### PR DESCRIPTION
I believe these were used before we had the config validation in place, but now they are obsolete.