### PR TITLE
Strip commas from channel keys

### DIFF
--- a/txircd/modules/rfc/cmode_k.py
+++ b/txircd/modules/rfc/cmode_k.py
@@ -25,7 +25,7 @@ class ChannelKeyMode(ModuleData, Mode):
 	def checkSet(self, channel, param):
 		if not param:
 			return None
-		password = param.split(" ")[0]
+		password = param.split(" ")[0].replace(",", "")
 		if not password:
 			return None
 		return [password]


### PR DESCRIPTION
Prevents commas in channel keys from messing up a JOIN command for multiple channels, as commas are used as the delimiter character for that.