### PR TITLE
Add a command alias module

### DIFF
--- a/conf/extra-modules-example.yaml
+++ b/conf/extra-modules-example.yaml
@@ -55,6 +55,10 @@ modules:
 # level.
 #- ChannelOpAccess
 
+# CommandAlias: Provides a way to make custom commands that act as an alias to 
+# an existing command.
+#- CommandAlias
+
 # ConnectionLimit: Provides a way to limit the maximum number of connections
 # from a single host. This module has some optional configuration (see below).
 # We highly recommend loading it.
@@ -200,6 +204,16 @@ modules:
 # to be specified, to avoid taking up too many system resources. The default
 # value is 50 and the hard cap is 100.
 #chanhistory_maxlines: 50
+
+# CommandAlias Configuration
+# This module requires a dictionary that specifies the aliases and the commands
+# they are replacing. The special value "%p" can be used to specify where the
+# given command parameters for the alias should be.
+# The given example would result in:
+# Input: user!ident@host HELP :I would like some help.
+# Output: user!ident@host PRIVMSG UsefulOper :I would like some help.
+#command_aliases:
+#  HELP: PRIVMSG UsefulOper %p
 
 # ConnectionLimit Configuration
 # This module has two options to set up, the maximum connections per host and

--- a/txircd/modules/extra/alias.py
+++ b/txircd/modules/extra/alias.py
@@ -1,0 +1,62 @@
+from twisted.plugin import IPlugin
+from txircd.config import ConfigValidationError
+from txircd.module_interface import Command, ICommand, IModuleData, ModuleData
+from zope.interface import implements
+import re
+
+validCommand = re.compile(r"^[A-Z]+$")
+
+class CommandAlias(ModuleData):
+	implements(IPlugin, IModuleData)
+
+	name = "CommandAlias"
+
+	def userCommands(self):
+		commands = []
+		for command, replacement in self.ircd.config.get("command_aliases", {}).iteritems():
+			commands.append((command, 1, UserAlias(replacement)))
+		return commands
+
+	def verifyConfig(self, config):
+		if "command_aliases" in config:
+			if not isinstance(config["command_aliases"], dict):
+				raise ConfigValidationError("command_aliases", "value must be a dictionary")
+			for command, replacement in config["command_aliases"].iteritems():
+				if not isinstance(command, basestring) or not validCommand.match(command):
+					raise ConfigValidationError("command_aliases", "alias \"{}\" is not a valid command".format(command))
+				if not isinstance(replacement, basestring):
+					raise ConfigValidationError("command_aliases", "replacement \"{}\" must be a string".format(replacement))
+				if any(replacementPart.startswith(":") for replacementPart in replacementParts) and "%p" in replacement:
+					raise ConfigValidationError("command_aliases", "replacement \"{}\" cannot have a final parameter in conjunction with %p".format(replacement))
+				replaceCommand = replacement.split(' ', 1)[0]
+				if not validCommand.match(replaceCommand):
+					raise ConfigValidationError("command_aliases", "replacement \"{}\" is not a valid command".format(replaceCommand))
+				if replaceCommand in config["command_aliases"]: # Prevent infinite recursion by disallowing aliases of aliases
+					raise ConfigValidationError("command_aliases", "replacement \"{}\" may not be used as a replacement because it is an alias".format(replaceCommand))
+
+class UserAlias(Command):
+	implements(ICommand)
+
+	def __init__(self, replacement):
+		self.replacement = replacement
+
+	def parseParams(self, user, params, prefix, tags):
+		return {
+			"params": params,
+			"prefix": prefix,
+			"tags": tags
+		}
+
+	def execute(self, user, data):
+		if " :" in self.replacement:
+			params, lastParam = self.replacement.split(" :", 1)
+		else:
+			params = self.replacement
+			lastParam = None
+		replacementParts = [x if x != "%p" else " ".join(data["params"]) for x in params.split(" ")]
+		if lastParam:
+			replacementParts.append(lastParam)
+		user.handleCommand(replacementParts[0], replacementParts[1:], data["prefix"], data["tags"])
+		return True
+
+commandAlias = CommandAlias()


### PR DESCRIPTION
What it says on the tin. It's very basic in concept. I wanted to make it so that you could actually split up the parameters but I figured that would get very messy and needlessly complicated as I can't think of a use case that would actually require splitting up the parameters.

For the validation I'm mainly just making sure all of the commands are actual valid commands and in all caps to keep the aliases consistent with the normal commands. We're also assuming people aren't stupid enough to use actual existing commands as aliases. We ARE however assuming people are stupid enough to create infinite recursions which would disastrous for the server, so we are checking for those.