### PR TITLE
Expose channel listmode limit through MAXLIST in ISUPPORT

### DIFF
--- a/txircd/modules/rfc/cmd_mode.py
+++ b/txircd/modules/rfc/cmd_mode.py
@@ -140,6 +140,7 @@ class ModeCommand(ModuleData):
 
 	def buildISupport(self, data):
 		data["MODES"] = self.ircd.config.get("modes_per_line", 20)
+		data["MAXLIST"] = "{}:{}".format("".join(self.ircd.channelModes[0].keys()), self.ircd.config.get("channel_listmode_limit", 128))
 
 class UserMode(Command):
 	implements(ICommand)


### PR DESCRIPTION
This token is the modern version of the old MAXBANS token and exposes to clients how long we allow our listmodes to be. The syntax for the value is `modechars:limit`. Since all of txircd's listmodes have the same limit, I simply used the first dictionary of `ircd`'s channel modes.