### PR TITLE
Fix typo in CHANELLEN ISUPPORT token

### DIFF
--- a/txircd/ircd.py
+++ b/txircd/ircd.py
@@ -688,7 +688,7 @@ class IRCd(Service):
 		isupport = self.isupport_tokens.copy()
 		statusSymbolOrder = "".join([self.channelStatuses[status][0] for status in self.channelStatusOrder])
 		isupport["CHANMODES"] = ",".join(["".join(modes) for modes in self.channelModes])
-		isupport["CHANNELEN"] = self.config.get("channel_name_length", 64)
+		isupport["CHANNELLEN"] = self.config.get("channel_name_length", 64)
 		isupport["MAXLIST"] = "{}:{}".format("".join(self.channelModes[0].keys()), self.config.get("channel_listmode_limit", 128))
 		isupport["NETWORK"] = self.config["network_name"]
 		isupport["PREFIX"] = "({}){}".format("".join(self.channelStatusOrder), statusSymbolOrder)


### PR DESCRIPTION
Discovered by @Didero. Apparently this typo has existed for a very long time. Might also wanna cherry-pick to master if we really care since the bug exists there too.