### PR TITLE
Fix some errors in the batch module and its usage

### DIFF
--- a/txircd/user.py
+++ b/txircd/user.py
@@ -183,7 +183,7 @@ class IRCUser(IRCBase):
 			if not self.ircd.runActionFlagTrue("commandunknown", self, command, params, {}):
 				self.sendMessage(irc.ERR_UNKNOWNCOMMAND, command, "Unknown command")
 	
-	def createMessageBatch(self, batchName, batchType, batchParameters = None):
+	def createMessageBatch(self, batchName, batchType, *batchParameters):
 		"""
 		Start a new message batch with the given batch name, type, and list of parameters.
 		If a batch with the given name already exists, that batch will be overwritten.
@@ -206,10 +206,10 @@ class IRCUser(IRCBase):
 			return
 		batchType = self._messageBatches[batchName]["type"]
 		batchParameters = self._messageBatches[batchName]["parameters"]
-		self.ircd.runActionStandard("startbatchsend", self, batchName, batchType, batchParameters)
+		self.ircd.runActionStandard("startbatchsend", self, batchName, batchType, *batchParameters)
 		for messageData in self._messageBatches[batchName]["messages"]:
 			self.sendMessage(messageData[0], *messageData[1], **messageData[2])
-		self.ircd.runActionStandard("endbatchsend", self, batchName, batchType, batchParameters)
+		self.ircd.runActionStandard("endbatchsend", self, batchName, batchType, *batchParameters)
 	
 	def startErrorBatch(self, batchName):
 		"""


### PR DESCRIPTION
The problems I fixed:
* Inconsistent usage of `*batchParameters` and `batchParameters` made it so when we send a string as a parameter (which is what you've done on 0.5), it splits it as if it was an array of parameters; In my case it resulted in `# g e n e r a l`
* The `BATCH` command should not include the username it is sent to, nor the batch id ([specs](https://ircv3.net/specs/extensions/batch-3.2))

Two things I would like feedback on:
* My usage of IRCBase seems a bit suspicious; I do mean to send it just to that user, so it may be the right thing to do, but I would still like a preview to make sure there's not a better way to do that.
* I added the `*` to `batchParameters` based on what made sense to me (and based on how you called it from the history module in 0.5), but I'm not a python programmer - so I may have been wrong on how I used that.